### PR TITLE
add minimal tests and travis-ci integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit = climlab/tests/*
+       */__init__.py
+       data/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Based on http://conda.pydata.org/docs/travis.html
+language: python
+sudo: false # use container based build
+notifications:
+  email: false
+
+matrix:
+  fast_finish: true
+
+python:
+  - 2.7
+# activate once you think you are python 3 compatible
+#  - 3.5
+
+env:
+  - CONDA_PACKAGES="numpy scipy pytest netcdf4"
+
+before_install:
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+
+install:
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION $CONDA_PACKAGES
+  - source activate test-environment
+  - pip install codecov pytest-cov
+  - pip install -e .
+
+script:
+  - py.test climlab --cov=climlab --cov-config .coveragerc --cov-report term-missing -v
+
+after_success:
+  - codecov

--- a/climlab/tests/test_grey_radiation.py
+++ b/climlab/tests/test_grey_radiation.py
@@ -1,0 +1,77 @@
+import numpy as np
+import climlab
+import pytest
+
+# The fixtures are reusable pieces of code to set up the input to the tests.
+# Without fixtures, we would have to do a lot of cutting and pasting
+# I inferred which fixtures to use from the notebook
+# Latitude-dependent grey radiation.ipynb
+@pytest.fixture()
+def model():
+    return climlab.GreyRadiationModel(num_lev=30, num_lat=90)
+
+@pytest.fixture()
+def model_with_insolation(model):
+    insolation = climlab.radiation.insolation.DailyInsolation(
+                                                        domains=model.Ts.domain)
+    model.add_subprocess('insolation', insolation)
+    model.subprocess.SW.flux_from_space = insolation.insolation
+    return model
+
+@pytest.fixture()
+def rcmodel():
+    model2 = climlab.RadiativeConvectiveModel(num_lev=30, num_lat=90)
+    insolation = climlab.radiation.insolation.DailyInsolation(domains=model2.Ts.domain)
+    model2.add_subprocess('insolation', insolation)
+    model2.subprocess.SW.flux_from_space = insolation.insolation
+    return model2
+
+@pytest.fixture()
+def diffmodel(rcmodel):
+    diffmodel = climlab.process_like(rcmodel)
+    # thermal diffusivity in W/m**2/degC
+    D = 0.05
+    # meridional diffusivity in 1/s
+    K = D / diffmodel.Tatm.domain.heat_capacity[0]
+    d = climlab.dynamics.diffusion.MeridionalDiffusion(K=K,
+                state={'Tatm': diffmodel.state['Tatm']}, **diffmodel.param)
+    diffmodel.add_subprocess('diffusion', d)
+    return diffmodel
+
+# helper for a common test pattern
+def _check_minmax(array, amin, amax):
+    return (np.allclose(array.min(), amin) and
+            np.allclose(array.max(), amax))
+
+def test_model_creation(model):
+    """Just make sure we can create a model."""
+    assert len(model.lat)==90
+
+def test_add_insolation(model_with_insolation):
+    """"Create a model with insolation and check that SW_down_TOA has
+    reasonable values."""
+    model_with_insolation.step_forward()
+    assert _check_minmax(model_with_insolation.SW_down_TOA, 0, 555.17111)
+
+def test_integrate_years(model_with_insolation):
+    """Check that we can integrate forward the model and get the expected
+    surface temperature."""
+    model_with_insolation.step_forward()
+    model_with_insolation.integrate_years(1)
+    ts = model_with_insolation.timeave['Ts']
+    assert _check_minmax(ts, 225.402329962, 301.659494398)
+
+def test_rcmodel(rcmodel):
+    """Check that we can integrate forwrd the radiative convective model and
+    get expected atmospheric temperature."""
+    rcmodel.step_forward()
+    rcmodel.integrate_years(1)
+    tatm = rcmodel.timeave['Tatm']
+    assert _check_minmax(tatm, 176.786517491, 292.222277112)
+
+def test_diffmodel(diffmodel):
+    """Check that we can integrate the model with diffusion."""
+    diffmodel.step_forward()
+    diffmodel.integrate_years(1)
+    tatm = diffmodel.timeave['Tatm']
+    assert _check_minmax(tatm, 208.689339823, 285.16085319)

--- a/climlab/tests/test_insolation.py
+++ b/climlab/tests/test_insolation.py
@@ -1,0 +1,34 @@
+import numpy as np
+from climlab import constants as const
+from climlab.solar.insolation import daily_insolation
+from climlab.solar.orbital import OrbitalTable
+
+# mostly copied from Insolation notebook
+def test_daily_insolation():
+    lat = np.linspace( -90., 90., 500. )
+    days = np.linspace(0, const.days_per_year, 365. )
+    Q = daily_insolation(lat, days)
+
+    # check the range of Q
+    np.testing.assert_almost_equal(Q.max(), 562.0333475)
+    np.testing.assert_almost_equal(Q.min(), 0.0)
+
+    # check the area integral
+    Q_area_int = (np.sum(np.mean(Q, axis=1) * np.cos(np.deg2rad(lat))) /
+                  np.sum(np.cos(np.deg2rad(lat))) )
+    np.testing.assert_almost_equal(Q_area_int, 341.384184481)
+
+def test_orbital_parameters():
+    kyears = np.arange( -1000., 1.)
+    table = OrbitalTable()
+    orb = table.lookup_parameters(kyears)
+
+    # check that orb has the right dictionary keys
+    # key: (min, max)
+    orb_expected = {'ecc': (0.004, 0.057),
+                    'long_peri': (2.3, 360),
+                    'obliquity': (22, 24.5) }
+
+    for k in orb_expected:
+        orb[k].min() > orb_expected[k][0]
+        orb[k].max() > orb_expected[k][0]


### PR DESCRIPTION
This adds some basic testing using the py.test framework, which I basically just copied from the Courseware notebooks. If you want to run the tests yourself, just type ``py.test -v`` (for verbose) in the project directory.

I also added support for continuous integration using [travis-ci](https://travis-ci.org/). Travis-ci (for "continuous integration") is a service that automatically builds the project and runs the tests every time a new commit or pull request is made. [Here is an example](https://travis-ci.org/rabernat/climlab/builds/109492019) of what travis-ci does on my climlab fork. If your testing is comprehensive, you can merge new pull requests with confidence after seeing that they don't break your tests. This makes it much easier for outsiders to contribute to the project. All travis-ci needs is a file called ``.travis.yml`` in the base directory.

Finally, I added a hook in the travis configuration to generate a [code coverage report](https://en.wikipedia.org/wiki/Code_coverage) and submit it to [codecov.io](https://codecov.io). The coverage report tells you how much of your code is covered by your tests, which is very useful to know. It took me 30 minutes to write a few basic tests, and we are already at [47% coverage](https://codecov.io/github/rabernat/climlab?branch=tests_and_travis-ci).

In order to get these features working on your repo, you will need to sign up for accounts at http://travis-ci.org and http://codecov.io.

Closes #8.
