### PR TITLE
added badges to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 ================
 climlab
 ================
+
+|pypi| |Build Status| |coverage|
+
 ----------
  Python package for process-oriented climate modeling
 ----------
@@ -99,3 +102,10 @@ License
 ---------------
 This code is freely available under the MIT license.
 See the accompanying LICENSE file.
+
+.. |pypi| image:: https://badge.fury.io/py/climlab.svg
+   :target: https://badge.fury.io/py/climlab
+.. |Build Status| image:: https://travis-ci.org/brian-rose/climlab.svg?branch=master
+    :target: https://travis-ci.org/brian-rose/climlab
+.. |coverage| image:: https://codecov.io/github/brian-rose/climlab/coverage.svg?branch=master
+   :target: https://codecov.io/github/brian-rose/climlab?branch=master


### PR DESCRIPTION
This adds those pretty badges to the README.rst file which link to the pypi package, the travis-ci build, and the codecov coverage report. This will give the package instant open source cred! ;)