### PR TITLE
add `gcc` to the list of conda packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 #  - 3.5
 
 env:
-  - CONDA_PACKAGES="numpy scipy pytest netcdf4"
+  - CONDA_PACKAGES="numpy scipy pytest netcdf4 gcc"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then


### PR DESCRIPTION
This should allow the test environment to build the CAM3Radiation module.