### PR TITLE
process.remove_subprocess warning

### DIFF
--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -258,7 +258,7 @@ class Process(object):
         else:
             raise ValueError('subprocess must be Process object')
 
-    def remove_subprocess(self, name):
+    def remove_subprocess(self, name, verbose=True):
         """Removes a single subprocess from this process.
         
         :param string name:     name of the subprocess
@@ -297,7 +297,11 @@ class Process(object):
                    insolation: <class 'climlab.radiation.insolation.P2Insolation'>
                 
         """
-        self.subprocess.pop(name, None)
+        try:
+            self.subprocess.pop(name)
+        except KeyError:
+            if verbose: 
+                print 'WARNING: Subprocess does not exist'
         self.has_process_type_list = False
         #  Since we made every subprocess an object attribute, we also remove
         #delattr(self, name)

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -261,7 +261,9 @@ class Process(object):
     def remove_subprocess(self, name, verbose=True):
         """Removes a single subprocess from this process.
         
-        :param string name:     name of the subprocess
+        :param string name:     name of the subprocess 
+        :param bool verbose:    information whether warning message 
+                                should be printed [default: True]
         
         :Example:
         
@@ -301,7 +303,7 @@ class Process(object):
             self.subprocess.pop(name)
         except KeyError:
             if verbose: 
-                print 'WARNING: Subprocess does not exist'
+                print 'WARNING: {} not found in subprocess dictionary.'.format(name)
         self.has_process_type_list = False
         #  Since we made every subprocess an object attribute, we also remove
         #delattr(self, name)


### PR DESCRIPTION
Warning message added in a place of a KeyError if a subprocess, not in the subprocess dictionary, is removed. Verbose option was added, with a default: Verbose = True.  
The actual message is a suggestion; I wanted to keep it short, but it may be useful to explicitly tell the user that the subprocess is not in the subprocess dictionary instead of the current message:

> WARNING: Subprocess does not exist

These changes do not seem to conflict with any of the documentation on remove_subprocess, but additional writing about the verbose option could be introduced.

This is in reference to issue #21 .    