### PR TITLE
fix Readthedocs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,3 +6,4 @@ dependencies:
     - netCDF4
     - sphinx=1.3.5
     - matplotlib
+    - nbsphinx


### PR DESCRIPTION
added nbsphinx to the dependencies in environment.yml so that the extension nbspinx can be imported 

This adds to PR #24 and is in reference to issue #17 .