### PR TITLE
Int to float conversion and test

### DIFF
--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -152,7 +152,7 @@ class Process(object):
         for name, value in states.iteritems():
             self.set_state(name, value)
         #convert int dtype to float
-            if self.state[name].dtype == (int):
+            if np.issubdtype(self.state[name].dtype, 'int'):
                 value = self.state[name].astype(float)
                 self.set_state(name, value)
         # dictionary of model parameters
@@ -364,7 +364,7 @@ class Process(object):
         self.state[name] = value
         for name, value in self.state.iteritems():
         #convert int dtype to float
-            if self.state[name].dtype == (int):
+            if np.issubdtype(self.state[name].dtype, 'int'):
                 value = self.state[name].astype(float)
                 self.state[name]=value
         setattr(self, name, value)

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -151,6 +151,10 @@ class Process(object):
         states = _make_dict(state, Field)
         for name, value in states.iteritems():
             self.set_state(name, value)
+        #convert int dtype to float
+            if self.state[name].dtype == (int):
+                value = self.state[name].astype(float)
+                self.set_state(name, value)
         # dictionary of model parameters
         self.param = kwargs
         # dictionary of diagnostic quantities
@@ -358,6 +362,11 @@ class Process(object):
                 raise ValueError('Shape mismatch between existing domain and new state variable.')
         # set the state dictionary
         self.state[name] = value
+        for name, value in self.state.iteritems():
+        #convert int dtype to float
+            if self.state[name].dtype == (int):
+                value = self.state[name].astype(float)
+                self.state[name]=value
         setattr(self, name, value)
 
     def _guess_state_domains(self):

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -57,3 +57,17 @@ def test_decreased_S0(EBM_iceline):
     EBM_iceline.subprocess['insolation'].S0 = 1200.
     EBM_iceline.integrate_years(5.)
     assert np.all(EBM_iceline.icelat == np.array([-0.,  0.]))
+    
+def test_float():
+    '''Check that we can step forward the model after setting the state 
+    variable with an ndarray of integers through 2 different methods'''
+    from climlab.domain import initial
+    from climlab.domain.field import Field
+    state = initial.surface_state()
+    sfc = climlab.domain.zonal_mean_surface(num_lat=4)
+    state.Ts = Field([10,15,15,10],domain=sfc)
+    m = climlab.EBM(state=state)
+    m.step_forward()
+    k = climlab.EBM(num_lat=4)
+    k.set_state('Ts', Field([10,15,15,10], domain=k.domains['Ts']))
+    k.step_forward()


### PR DESCRIPTION
Conversion method was added to process.py from dtype(int) to dtype(float) when setting a state variable.  Without the conversion a TypeError is raised when setting the state variable using 2 different methods...this conversion needed to be added in the 2 areas where the state variable is set.  

Also added is a test in test_ebm.py, which creates 2 models and sets the state variable 2 different ways with integers (the test passed locally). 

This is in references to issue #29 .