### PR TITLE
2D domain and surface state

### DIFF
--- a/climlab/domain/domain.py
+++ b/climlab/domain/domain.py
@@ -79,6 +79,7 @@ class _Domain(object):
         #  lat is second-last
         add_lev = False
         add_depth = False
+        add_lon = False
         add_lat = False
         axlist = self.axes.keys()
         if 'lev' in axlist:
@@ -87,12 +88,17 @@ class _Domain(object):
         elif 'depth' in axlist:
             axlist.remove('depth')
             add_depth = True
+        if 'lon' in axlist:
+            axlist.remove('lon')
+            add_lon = True
         if 'lat' in axlist:
             axlist.remove('lat')
             add_lat = True
         axlist2 = axlist[:]
         if add_lat:
             axlist2.append('lat')
+        if add_lon:
+            axlist2.append('lon')
         if add_depth:
             axlist2.append('depth')
         if add_lev:
@@ -466,6 +472,62 @@ def zonal_mean_surface(num_lat=90, water_depth=10., lat=None, **kwargs):
             raise ValueError('lat must be Axis object or latitude array')
     depthax = Axis(axis_type='depth', bounds=[water_depth, 0.])
     axes = {'depth': depthax, 'lat': latax}
+    slab = SlabOcean(axes=axes, **kwargs)
+    return slab
+
+def surface_2D(num_lat=90, num_lon=180, water_depth=10., lon=None, 
+               lat=None, **kwargs):
+    """Creates a Domain with one water cell, and latitude and longitude axes above.
+    
+    Domain has a single heat capacity according to the specified water depth.
+    
+    **Function-call argument** \n        
+    
+    :param int num_lat:         number of latitude points on the axis
+                                [default: 90]
+    :param int num_lon:         number of longitude points on the axis
+                                [default: 180]                       
+    :param float water_depth:   depth of the water cell (slab ocean) [default: 10.]
+    :param lat:                 specification for latitude axis (optional)
+    :type lat:                  :class:`~climlab.domain.axis.Axis` or latitude array
+    :param lon:                 specification for longitude axis (optional)
+    :type lon:                  :class:`~climlab.domain.axis.Axis` or longitude array
+    :raises: :exc:`ValueError`  if `lat` is given but neither Axis nor latitude array.
+    :raises: :exc:`ValueError`  if `lon` is given but neither Axis nor longitude array.
+    :returns:                   surface domain
+    :rtype:                     :class:`SlabOcean`
+
+    :Example:
+    
+        ::
+        
+            >>> from climlab import domain
+            >>> sfc = domain.surface_2D(num_lat=36, num_lat=72)
+            
+            >>> print sfc
+            climlab Domain object with domain_type=ocean and shape=(36, 72, 1)
+            
+    """
+    if lat is None:
+        latax = Axis(axis_type='lat', num_points=num_lat)
+    elif isinstance(lat, Axis):
+        latax = lat
+    else:
+        try:
+            latax = Axis(axis_type='lat', points=lat)
+        except:
+            raise ValueError('lat must be Axis object or latitude array')
+    if lon is None:
+        lonax = Axis(axis_type='lon', num_points=num_lon)
+    elif isinstance(lon, Axis):
+        lonax = lon
+    else:
+        try:
+            lonax = Axis(axis_type='lon', points=lon)
+        except:
+            raise ValueError('lon must be Axis object or longitude array')
+    depthax = Axis(axis_type='depth', bounds=[water_depth, 0.])
+    axes = {'lat': latax, 'lon': lonax, 'depth': depthax}
     slab = SlabOcean(axes=axes, **kwargs)
     return slab
 

--- a/climlab/domain/initial.py
+++ b/climlab/domain/initial.py
@@ -140,3 +140,69 @@ def surface_state(num_lat=90,
     state = AttrDict()
     state['Ts'] = Ts
     return state
+
+def surface_state_2D(num_lat=90,
+                     num_lon=180,
+                     water_depth=10.,
+                     T0=12.,
+                     T2=-40.):
+    """Sets up a state variable dictionary for a two-dimensional surface model
+    (e.g. 2D EBM). 
+    
+    Returns a single state variable `Ts`, the temperature of the surface 
+    mixed layer, initialized by a basic temperature and the second Legendre
+    polynomial.
+    
+    **Function-call arguments** \n        
+        
+    :param int num_lat:         number of latitude points on the axis
+                                [default: 90]
+    :param int num_lon:         number of longitude points on the axis
+                                [default: 180]
+    :param float water_depth:   *irrelevant*
+    :param float T0:            base value for initial temperature          \n
+                                - unit :math:`^{\circ} \\textrm{C}`         \n
+                                - default value: ``12``
+    :param float T2:            factor for 2nd Legendre polynomial 
+                                :class:`~climlab.utils.legendre.P2` 
+                                to calculate initial temperature            \n
+                                - unit: dimensionless
+                                - default value: ``-40``
+
+    :returns:                   dictionary with temperature 
+                                :class:`~climlab.domain.field.Field` 
+                                for surface mixed layer ``Ts``
+    :rtype:                     dict
+    
+    
+    :Example:
+    
+        ::
+        
+            >>> from climlab.domain import initial
+            >>> import numpy as np
+            
+            >>> T_dict = initial.surface_state_2D(num_lat=5, num_lon=10)
+            
+            >>> print np.squeeze(T_dict['Ts'])
+            [[-22.27050983 -22.27050983 -22.27050983 -22.27050983 -22.27050983
+              -22.27050983 -22.27050983 -22.27050983 -22.27050983 -22.27050983]
+             [ 11.27050983  11.27050983  11.27050983  11.27050983  11.27050983
+               11.27050983  11.27050983  11.27050983  11.27050983  11.27050983]
+             [ 32.          32.          32.          32.          32. 
+               32.          32.          32.          32.          32.        ]
+             [ 11.27050983  11.27050983  11.27050983  11.27050983  11.27050983
+               11.27050983  11.27050983  11.27050983  11.27050983  11.27050983]
+             [-22.27050983 -22.27050983 -22.27050983 -22.27050983 -22.27050983
+              -22.27050983 -22.27050983 -22.27050983 -22.27050983 -22.27050983]]
+
+    """
+    sfc = domain.surface_2D(num_lat=num_lat,
+                            num_lon=num_lon,
+                            water_depth=water_depth)
+    sinphi = np.sin(np.deg2rad(sfc.axes['lat'].points))
+    initial = T0 + T2 * legendre.P2(sinphi) 
+    Ts = Field([[initial for k in range(num_lon)]], domain=sfc) 
+    state = AttrDict()
+    state['Ts'] = Ts
+    return state

--- a/climlab/tests/test_domain2D.py
+++ b/climlab/tests/test_domain2D.py
@@ -5,6 +5,8 @@ import pytest
 
 def test_state():
     sfc = domain.surface_2D(num_lat=90, num_lon=180)
+    sfc = domain.surface_2D(lat=([-90.,0.,90.]),
+                            lon=([-180.,0.,180.]))
     state = initial.surface_state_2D(num_lat=90, num_lon=180)
     assert state.Ts.ndim == 3
     assert state.Ts[:,0,0].shape == (90,)

--- a/climlab/tests/test_domain2D.py
+++ b/climlab/tests/test_domain2D.py
@@ -1,0 +1,12 @@
+import climlab
+from climlab import domain
+from climlab.domain import initial
+import pytest
+
+def test_state():
+    sfc = domain.surface_2D(num_lat=90, num_lon=180)
+    state = initial.surface_state_2D(num_lat=90, num_lon=180)
+    assert state.Ts.ndim == 3
+    assert state.Ts[:,0,0].shape == (90,)
+    assert state.Ts[0,:,0].shape == (180,)
+    


### PR DESCRIPTION
surface_2D creates the 2D domain and surface_state_2D sets up the state variable dictionary
-  in domain.py I added lon earlier in the code to ensure that lon is the 2nd dimension

- in initial.py the initial Ts is initialized with the 2nd legendre polynomial at each longitude 

- documentation and examples are included 

as of now, the budyko transport cannot step forward with the 2D state, but I will create an issue and  submit a pull request of the change needed after this is merged 

