### PR TITLE
Insolation for a 2D domain

### DIFF
--- a/climlab/domain/field.py
+++ b/climlab/domain/field.py
@@ -356,8 +356,38 @@ def _global_mean_latlon(field):
     return np.average(field, weights=area)
 
 
-def to_latlon(array, domain = None, axis = 'lon'):
-    #  broadcasts a 1D axis dependent array onto onother axis
+def to_latlon(array, domain, axis = 'lon'):
+    """Broadcasts a 1D axis dependent array accros another axis.
+    
+    :param array input_array:   the 1D array used for broadcasting
+    :param domain:              the domain associated with that
+                                array
+    :param axis:                the axis that the input array will 
+                                be broadcasted across 
+                                [default: 'lon']
+    :return:                    Field with the same shape as the 
+                                domain
+    :Example:
+
+        ::
+            
+            >>> import climlab
+            >>> from climlab.domain.field import to_latlon
+            >>> import numpy as np
+            
+            >>> state = climlab.surface_state(num_lat=3, num_lon=4)
+            >>> m = climlab.EBM_annual(state=state)
+            >>> insolation = np.array([237., 417., 237.])
+            >>> insolation = to_latlon(insolation, domain = m.domains['Ts'])
+            >>> insolation.shape
+            (3, 4, 1)
+            >>> insolation
+            Field([[[ 237.],   [[ 417.],   [[ 237.],
+                    [ 237.],    [ 417.],    [ 237.],
+                    [ 237.],    [ 417.],    [ 237.],
+                    [ 237.]],   [ 417.]],   [ 237.]]])
+                
+    """
     #  if array is latitude dependent (has the same shape as lat)
     axis, array, depth = np.meshgrid(domain.axes[axis].points, array, 
                                     domain.axes['depth'].points)

--- a/climlab/domain/field.py
+++ b/climlab/domain/field.py
@@ -354,3 +354,14 @@ def _global_mean_latlon(field):
     dx = np.deg2rad(np.diff(dom.lon.bounds))*np.cos(np.deg2rad(lat))
     area = dx * dy[:,np.newaxis]  # grid cell area in radians^2
     return np.average(field, weights=area)
+
+
+def to_latlon(array, domain = None, axis = 'lon'):
+    #  broadcasts a 1D axis dependent array onto onother axis
+    #  if array is latitude dependent (has the same shape as lat)
+    axis, array, depth = np.meshgrid(domain.axes[axis].points, array, 
+                                    domain.axes['depth'].points)
+    if axis == 'lat':
+    #  if array is longitude dependent (has the same shape as lon)    
+        np.swapaxes(array,1,0)      
+    return Field(array, domain=domain)

--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -1,6 +1,7 @@
 import numpy as np
 from climlab.process.diagnostic import DiagnosticProcess
 from climlab.domain.field import Field
+from climlab.domain.field import to_latlon
 from climlab.utils.legendre import P2
 from climlab import constants as const
 from climlab.solar.insolation import daily_insolation
@@ -218,16 +219,17 @@ class P2Insolation(_Insolation):
         #  Why is there a silent fail here? Should get rid of this.
         try:
             insolation = self.S0 / 4 * (1. + self.s2 * P2(np.sin(phi)))
-            try:
-                if self.lon.all():
-                    insolation = np.array([insolation for i in range(self.lon.size)])
-                    insolation = np.swapaxes(insolation,1,0)
-            except ValueError:
-                pass
-            # make sure that the diagnostic has the correct field dimensions.
             dom = self.domains['default']
+            try:
+                insolation = to_latlon(insolation, domain=dom)
+                self.insolation[:] = insolation
+            except:                    
+                self.insolation[:] = Field(insolation, domain=dom)
+            # make sure that the diagnostic has the correct field dimensions.
             #self.insolation = Field(insolation, domain=dom)
             self.insolation[:] = Field(insolation, domain=dom)
+        #  Silent fail only for attribute error: _s2 is not an attribute of self 
+        #  but s2 parameter is being stored in self._s2 
         except AttributeError:
             pass
 
@@ -387,15 +389,15 @@ class AnnualMeanInsolation(_Insolation):
         try:
             temp_array = self._daily_insolation_array()
             insolation = np.mean(temp_array, axis=1)
-            try:
-                if self.lon.all():
-                    insolation = np.array([insolation for i in range(self.lon.size)])
-                    insolation = np.swapaxes(insolation,1,0)
-            except ValueError:
-                pass
             # make sure that the diagnostic has the correct field dimensions.
             dom = self.domains['default']
-            self.insolation[:] = Field(insolation, domain=dom)
+            try:
+                insolation = to_latlon(insolation, domain=dom)
+                self.insolation[:] = insolation
+            except:                    
+                self.insolation[:] = Field(insolation, domain=dom)
+        #  Silent fail only for attribute error: _orb is not an attribute of self 
+        #  but orb parameter is being stored in self._orb 
         except AttributeError:
             pass
 

--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -218,11 +218,17 @@ class P2Insolation(_Insolation):
         #  Why is there a silent fail here? Should get rid of this.
         try:
             insolation = self.S0 / 4 * (1. + self.s2 * P2(np.sin(phi)))
+            try:
+                if self.lon.all():
+                    insolation = np.array([insolation for i in range(self.lon.size)])
+                    insolation = np.swapaxes(insolation,1,0)
+            except ValueError:
+                pass
             # make sure that the diagnostic has the correct field dimensions.
             dom = self.domains['default']
             #self.insolation = Field(insolation, domain=dom)
             self.insolation[:] = Field(insolation, domain=dom)
-        except:
+        except AttributeError:
             pass
 
 
@@ -381,10 +387,16 @@ class AnnualMeanInsolation(_Insolation):
         try:
             temp_array = self._daily_insolation_array()
             insolation = np.mean(temp_array, axis=1)
+            try:
+                if self.lon.all():
+                    insolation = np.array([insolation for i in range(self.lon.size)])
+                    insolation = np.swapaxes(insolation,1,0)
+            except ValueError:
+                pass
             # make sure that the diagnostic has the correct field dimensions.
             dom = self.domains['default']
             self.insolation[:] = Field(insolation, domain=dom)
-        except:
+        except AttributeError:
             pass
 
 
@@ -494,7 +506,7 @@ class DailyInsolation(AnnualMeanInsolation):
     def _compute_fixed(self):
         try:
             self.insolation_array = self._daily_insolation_array()
-        except:
+        except AttributeError:
             pass
 
     def _get_current_insolation(self):

--- a/climlab/tests/test_domain2D.py
+++ b/climlab/tests/test_domain2D.py
@@ -20,3 +20,15 @@ def test_2D_EBM():
     m.step_forward()
     assert m.state.Ts.shape == (90, 4, 1)
     
+def test_2D_insolation():
+    state = climlab.surface_state(num_lon=4)
+    m = climlab.EBM_annual(state=state)
+    #  the answers are the mean of 1D insolation arrays
+    #  the mean shouldn't change from 1D to 2D...
+    #  there are exactly the same amount of each number in 2D array
+    assert np.mean(m.subprocess['insolation'].insolation) == 299.30467670961832
+    from climlab.radiation.insolation import P2Insolation
+    sfc = m.domains['Ts']
+    m.add_subprocess('insolation', P2Insolation(domains=sfc, **m.param))
+    assert np.mean(m.subprocess['insolation'].insolation) == 300.34399999999999    
+


### PR DESCRIPTION
 to_latlon was added to field.py and is used in 2 spots in insolation.py

- P2 insolation and annual mean insolation are now computed for 1D and 2D domains using np.meshgrid

- the axis that the array is broadcasted on is longitude, but this can be set to latitude if the array is longitude dependent 

A test for the creation of non-zero insolation arrays with 2D domains was also included

This is in reference to issue #34 
 