### PR TITLE
Integrate an EBM forward after changing the albedo

### DIFF
--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -187,6 +187,7 @@ class EBM(EnergyBudget):
         self.init_diagnostic('icelat', None)
 
 
+
     def _compute_heating_rates(self):
         """Computes energy flux convergences to get heating rates in :math:`W/m^2`
         
@@ -201,7 +202,11 @@ class EBM(EnergyBudget):
         self.heating_rate['Ts'] = self.ASR
         # useful diagnostics
         try:
-            self.icelat = self.subprocess['albedo'].subprocess['iceline'].icelat
+            if 'iceline' not in self.subprocess['albedo'].subprocess:
+                self.remove_diagnostic('icelat')
+            else:
+                self.init_diagnostic('icelat', None)
+                self.icelat = self.subprocess['albedo'].subprocess['iceline'].icelat
         except:
             pass
 

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -187,7 +187,6 @@ class EBM(EnergyBudget):
         self.init_diagnostic('icelat', None)
 
 
-
     def _compute_heating_rates(self):
         """Computes energy flux convergences to get heating rates in :math:`W/m^2`
         
@@ -202,13 +201,9 @@ class EBM(EnergyBudget):
         self.heating_rate['Ts'] = self.ASR
         # useful diagnostics
         try:
-            if 'iceline' not in self.subprocess['albedo'].subprocess:
-                self.remove_diagnostic('icelat')
-            else:
-                self.init_diagnostic('icelat', None)
-                self.icelat = self.subprocess['albedo'].subprocess['iceline'].icelat
-        except:
-            pass
+            self.icelat = self.subprocess['albedo'].subprocess['iceline'].icelat
+        except KeyError, icelat:
+            self.icelat = None
 
     def global_mean_temperature(self):
         """Convenience method to compute global mean surface temperature.

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -362,6 +362,10 @@ class TimeDependentProcess(Process):
                 self.timeave.update(self.diagnostics)
                 # reset all values to zero
                 for varname, value in self.timeave.iteritems():
+                # moves on to the next varname if value is None
+                # this preserves NoneType diagnostics
+                    if value is None:
+                        continue
                     self.timeave[varname] = 0*value
             # adding up all values for each timestep
             for varname in self.timeave.keys():
@@ -372,7 +376,9 @@ class TimeDependentProcess(Process):
                         self.timeave[varname] += self.diagnostics[varname]
                     except: pass
         # calculating mean values through dividing the sum by number of steps
-        for varname in self.timeave.keys():
+        for varname, value in self.timeave.iteritems():
+            if value is None:
+                continue 
             self.timeave[varname] /= numsteps
         if verbose:
             print("Total elapsed time is %s years."

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -71,3 +71,16 @@ def test_float():
     k = climlab.EBM(num_lat=4)
     k.set_state('Ts', Field([10,15,15,10], domain=k.domains['Ts']))
     k.step_forward()
+    
+def test_albedo():
+    '''Check that we can integrate forward a model after changing the albedo 
+    subprocess and get the expected icelat (ice at 70 degrees and no ice
+    respectively'''
+    import numpy as np
+    from climlab.surface import albedo
+    m = climlab.EBM()
+    m.integrate_years(10.)
+    assert np.all(m.icelat == np.array([-70.,  70.]))
+    m.add_subprocess('albedo', albedo.ConstantAlbedo(state=m.state, **m.param))
+    m.integrate_years(10.)
+    assert 'icelat' not in m.diagnostics

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -74,13 +74,17 @@ def test_float():
     
 def test_albedo():
     '''Check that we can integrate forward a model after changing the albedo 
-    subprocess and get the expected icelat (ice at 70 degrees and no ice
-    respectively'''
+    subprocess and get the expected icelat'''
     import numpy as np
     from climlab.surface import albedo
     m = climlab.EBM()
-    m.integrate_years(10.)
+    m.add_subprocess('albedo', albedo.ConstantAlbedo(state=m.state, **m.param))
+    m.integrate_years(1)
+    assert m.icelat == None
+    m.add_subprocess('albedo', albedo.StepFunctionAlbedo(state=m.state, **m.param))
+    m.integrate_years(1)
     assert np.all(m.icelat == np.array([-70.,  70.]))
     m.add_subprocess('albedo', albedo.ConstantAlbedo(state=m.state, **m.param))
-    m.integrate_years(10.)
-    assert 'icelat' not in m.diagnostics
+    m.integrate_years(1)
+    assert m.icelat == None
+    


### PR DESCRIPTION
The problem when integrating forward was the 'icelat' diagnostic having the datatype NoneType.  I added code that removes the 'icelat' diagnostic if 'iceline' is not a subprocess of the albedo subprocess.  Ideally, the diagnostic would remain and would return None if model.icelat is called, but I couldn't find a way to do this.  I also initialized the 'icelat' diagnostic again if the user changes back to an albedo subprocess that needs the diagnostic.

I have also included a test that changes the albedo and integrates forward, then asserts that the 'icelat' returned is expected.  

This is in reference to issue #36  .