### PR TITLE
Add Python 3 compatibility!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - 3.6
 
 env:
-  - CONDA_PACKAGES="conda-build pip pytest gcc"
+  - CONDA_PACKAGES="pip pytest gcc"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
 python:
   - 2.7
   - 3.5
+  - 3.6
 
 env:
   - CONDA_PACKAGES="codecov pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels conda-forge
   - conda update -q conda
   - conda install conda-build
   - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - 3.6
 
 env:
-  - CONDA_PACKAGES="pip pytest gcc"  # numpy version hard-coded for now
+  - CONDA_PACKAGES="conda-build pip pytest gcc"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -31,7 +31,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION $CONDA_PACKAGES
   - source activate test-environment
   - pip install codecov pytest-cov
-  - conda build conda-recipe --numpy 1.13  # hard-coded for now... better to have a build matrix
+  - conda-build conda-recipe --numpy 1.13  # hard-coded for now... better to have a build matrix
   - conda install climlab --use-local
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ env:
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ matrix:
 
 python:
   - 2.7
-  - 3.6
+#  - 3.6
 
 env:
-  - CONDA_PACKAGES="codecov"
+  - CONDA_PACKAGES="codecov pytest"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -31,6 +31,10 @@ before_install:
 
 install:
   - conda-build conda-recipe --numpy 1.13  # hard-coded for now... better to have a build matrix
+  - conda install climlab --use-local
+
+script:
+  - pytest -v -m fast --pyargs climlab.tests --cov=climlab --cov-config .coveragerc --cov-report term-missing -v
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ matrix:
 
 python:
   - 2.7
-# activate once you think you are python 3 compatible
-#  - 3.5
+  - 3.6
 
 env:
-  - CONDA_PACKAGES="numpy scipy pytest netcdf4 gcc future"
+  - CONDA_PACKAGES="pip pytest gcc"  # numpy version hard-coded for now
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -32,7 +31,8 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION $CONDA_PACKAGES
   - source activate test-environment
   - pip install codecov pytest-cov
-  - pip install -e .
+  - conda build conda-recipe --numpy 1.13  # hard-coded for now... better to have a build matrix
+  - conda install climlab --use-local
 
 script:
   - py.test climlab --cov=climlab --cov-config .coveragerc --cov-report term-missing -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
 python:
   - 2.7
-#  - 3.6
+  - 3.5
 
 env:
   - CONDA_PACKAGES="codecov pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,18 +23,19 @@ before_install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge
-  - conda update -q conda
-  - conda install conda-build
-  - conda info -a
 
 install:
-  - conda-build conda-recipe --numpy 1.13  # hard-coded for now... better to have a build matrix
-  - conda install climlab --use-local
+  - |
+      echo ""
+      echo "Configuring conda."
+      conda config --set always_yes yes --set changeps1 no
+      conda config --add channels conda-forge
+      conda update -q conda
+      conda install conda-build
+      conda info -a
 
 script:
-  - pytest -v -m fast --pyargs climlab.tests --cov=climlab --cov-config .coveragerc --cov-report term-missing -v
+  - conda-build conda-recipe --numpy 1.13  # hard-coded for now... better to have a build matrix
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+  - conda install conda-build
   - conda info -a
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - 3.6
 
 env:
-  - CONDA_PACKAGES="pip pytest gcc"
+  - CONDA_PACKAGES="codecov"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -30,14 +30,7 @@ before_install:
   - conda info -a
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION $CONDA_PACKAGES
-  - source activate test-environment
-  - pip install codecov pytest-cov
   - conda-build conda-recipe --numpy 1.13  # hard-coded for now... better to have a build matrix
-  - conda install climlab --use-local
-
-script:
-  - py.test climlab --cov=climlab --cov-config .coveragerc --cov-report term-missing -v
 
 after_success:
   - codecov

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ These are handled automatically if you install with conda_.
 
 Required
 ~~~~~~~~~~~~
-- Python 2.7  (compatibility with Python 3 coming soon!)
+- Python 2.7, 3.5, or 3.6 (as of version 0.6.0)
 - ``numpy``
 - ``scipy``
 - ``netCDF4`` Python package (for data i/o)
@@ -178,6 +178,8 @@ Version 0.5.2 (released late March 2017) provides many under-the-hood improvemen
 which should make it much easier to get `climlab` installed on user machines. Binary distribution with conda_ is coming soon!
 
 Version 0.5.5 (released early April 2017) finally provides easy binary distrbution with conda_
+
+Version 0.6.0 (released October 2017) provides full Python 3 compatibility.
 
 The documentation_ was first created by Moritz Kreuzer (Potsdam Institut for Climate Impact Research) as part of a thesis project in Spring 2016.
 

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev7'
+__version__ = '0.6.0.dev8'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev8'
+__version__ = '0.6.0.dev9'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev9'
+__version__ = '0.6.0.dev10'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev5'
+__version__ = '0.6.0.dev6'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev3'
+__version__ = '0.6.0.dev4'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.5.7.dev0'
+__version__ = '0.6.0.dev0'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev0'
+__version__ = '0.6.0.dev1'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev4'
+__version__ = '0.6.0.dev5'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev2'
+__version__ = '0.6.0.dev3'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev1'
+__version__ = '0.6.0.dev2'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev6'
+__version__ = '0.6.0.dev7'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/convection/__init__.py
+++ b/climlab/convection/__init__.py
@@ -3,4 +3,5 @@ Modules for atmospheric convection.
 
 Currently limited to simple hard convective adjustment to prescribed lapse rate.
 '''
-from convadj import ConvectiveAdjustment
+from __future__ import absolute_import
+from .convadj import ConvectiveAdjustment

--- a/climlab/convection/convadj.py
+++ b/climlab/convection/convadj.py
@@ -4,6 +4,7 @@ import numpy as np
 from climlab import constants as const
 from climlab.process.time_dependent_process import TimeDependentProcess
 from climlab.domain.field import Field
+import sys
 
 
 class ConvectiveAdjustment(TimeDependentProcess):
@@ -266,9 +267,15 @@ def Akamaev_adjustment(theta, q, beta, n_k, theta_k, s_k, t_k):
 #  which gives at least 10x speedup
 #   If numba is not available or compilation fails, the code will be executed
 #   in pure Python. Results should be identical
-try:
-    from numba import jit
-    Akamaev_adjustment = jit(signature_or_function=Akamaev_adjustment)
-    #print 'Compiling Akamaev_adjustment() with numba.'
-except:
-    pass
+
+###  ONLY DO THIS IN PYTHON 2!
+#  Because of a bug in numba for while / break loops that is causing all calls
+#  to ConvectiveAdjustment to hang forever!
+#   https://github.com/numba/numba/issues/2273
+if sys.version_info < (3,0):
+    try:
+        from numba import jit
+        Akamaev_adjustment = jit(signature_or_function=Akamaev_adjustment)
+        #print 'Compiling Akamaev_adjustment() with numba.'
+    except:
+        pass

--- a/climlab/convection/convadj.py
+++ b/climlab/convection/convadj.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import range
 import numpy as np
 from climlab import constants as const
 from climlab.process.time_dependent_process import TimeDependentProcess

--- a/climlab/domain/axis.py
+++ b/climlab/domain/axis.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import str
+from builtins import object
 import numpy as np
 from climlab import constants as const
 

--- a/climlab/domain/domain.py
+++ b/climlab/domain/domain.py
@@ -1,4 +1,6 @@
 from __future__ import division
+from builtins import str
+from builtins import object
 from climlab.domain.axis import Axis
 from climlab.utils import heat_capacity
 
@@ -68,7 +70,7 @@ class _Domain(object):
         # self.axes should be a dictionary of axes
         # make it possible to give just a single axis:
         self.axes = self._make_axes_dict(axes)
-        self.numdims = len(self.axes.keys())
+        self.numdims = len(list(self.axes.keys()))
         shape = []
         axcount = 0
         axindex = {}
@@ -79,7 +81,7 @@ class _Domain(object):
         add_depth = False
         add_lon = False
         add_lat = False
-        axlist = self.axes.keys()
+        axlist = list(self.axes.keys())
         if 'lev' in axlist:
             axlist.remove('lev')
             add_lev = True

--- a/climlab/dynamics/__init__.py
+++ b/climlab/dynamics/__init__.py
@@ -1,3 +1,4 @@
 '''Modules for horizontal transport processes in climlab.'''
-from budyko_transport import BudykoTransport
-from diffusion import Diffusion, MeridionalDiffusion
+from __future__ import absolute_import
+from .budyko_transport import BudykoTransport
+from .diffusion import Diffusion, MeridionalDiffusion

--- a/climlab/dynamics/budyko_transport.py
+++ b/climlab/dynamics/budyko_transport.py
@@ -67,5 +67,5 @@ class BudykoTransport(EnergyBudget):
         """Computes energy flux convergences to get heating rates in :math:`W/m^2`.
 
         """
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             self.heating_rate[varname] = - self.b * (value - global_mean(value))

--- a/climlab/dynamics/budyko_transport.py
+++ b/climlab/dynamics/budyko_transport.py
@@ -4,7 +4,7 @@ from climlab.domain.field import global_mean
 
 
 class BudykoTransport(EnergyBudget):
-    """calculates the 1 dimensional heat transport as the difference
+    r"""calculates the 1 dimensional heat transport as the difference
     between the local temperature and the global mean temperature.
 
     :param float b:     budyko transport parameter                      \n
@@ -49,7 +49,7 @@ class BudykoTransport(EnergyBudget):
 
     @property
     def b(self):
-        """the budyko transport parameter in unit
+        r"""the budyko transport parameter in unit
         :math:`\\frac{\\textrm{W}}{\\textrm{m}^2 \\textrm{K}}`
 
         :getter: returns the budyko transport parameter

--- a/climlab/dynamics/diffusion.py
+++ b/climlab/dynamics/diffusion.py
@@ -82,7 +82,7 @@ class Diffusion(ImplicitProcess):
         else:
             self.diffusion_axis = diffusion_axis
         # This currently only works with evenly spaced points
-        for dom in self.domains.values():
+        for dom in list(self.domains.values()):
             delta = np.mean(dom.axes[self.diffusion_axis].delta)
             bounds = dom.axes[self.diffusion_axis].bounds
         self.K_dimensionless = (self.param['K'] * np.ones_like(bounds) *
@@ -131,7 +131,7 @@ class Diffusion(ImplicitProcess):
         # Time-stepping the diffusion is just inverting this matrix problem:
         # self.T = np.linalg.solve( self.diffTriDiag, Trad )
         newstate = {}
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             if self.use_banded_solver:
                 newvar = _solve_implicit_banded(value, self.diffTriDiag)
             else:
@@ -223,7 +223,7 @@ class MeridionalDiffusion(Diffusion):
                                                 diffusion_axis='lat', **kwargs)
         # Conversion of delta from deg to rad in K_dimensionless
         self.K_dimensionless *= 1./np.deg2rad(1.)**2
-        for dom in self.domains.values():
+        for dom in list(self.domains.values()):
             latax = dom.axes['lat']
         self.diffTriDiag = \
             _make_meridional_diffusion_matrix(self.K_dimensionless, latax)
@@ -399,10 +399,10 @@ def _guess_diffusion_axis(process_or_domain):
     """
     axes = get_axes(process_or_domain)
     diff_ax = {}
-    for axname, ax in axes.iteritems():
+    for axname, ax in axes.items():
         if ax.num_points > 1:
             diff_ax.update({axname: ax})
-    if len(diff_ax.keys()) == 1:
-        return diff_ax.keys()[0]
+    if len(list(diff_ax.keys())) == 1:
+        return list(diff_ax.keys())[0]
     else:
         raise ValueError('More than one possible diffusion axis.')

--- a/climlab/model/column.py
+++ b/climlab/model/column.py
@@ -112,7 +112,7 @@ class GreyRadiationModel(TimeDependentProcess):
         self.do_diagnostics()
         # no tendencies for the parent process
         tendencies = {}
-        for name, var in self.state.iteritems():
+        for name, var in self.state.items():
             tendencies[name] = var * 0.
         return tendencies
 

--- a/climlab/model/stommelbox.py
+++ b/climlab/model/stommelbox.py
@@ -5,13 +5,14 @@
 # how easy is to implement the Stommel 1961 box model in climlab?
 #  currently... it still requires a fair bit of code:
 from __future__ import division
+from __future__ import print_function
 import numpy as np
 from climlab.process.time_dependent_process import TimeDependentProcess
 from climlab.domain import domain, field
 
 
 box = domain.box_model_domain()
-print box.shape
+print(box.shape)
 
 # initial condition
 x = field.Field([1.,0.], domain=box)

--- a/climlab/process/__init__.py
+++ b/climlab/process/__init__.py
@@ -1,6 +1,7 @@
 '''The base classes for all climlab processes.'''
-from process import Process, process_like, get_axes
-from time_dependent_process import TimeDependentProcess
-from implicit import ImplicitProcess
-from diagnostic import DiagnosticProcess
-from energy_budget import EnergyBudget
+from __future__ import absolute_import
+from .process import Process, process_like, get_axes
+from .time_dependent_process import TimeDependentProcess
+from .implicit import ImplicitProcess
+from .diagnostic import DiagnosticProcess
+from .energy_budget import EnergyBudget

--- a/climlab/process/energy_budget.py
+++ b/climlab/process/energy_budget.py
@@ -53,13 +53,13 @@ class EnergyBudget(TimeDependentProcess):
         This method should be over-ridden by daughter classes.
 
         """
-        for varname in self.state.keys():
+        for varname in list(self.state.keys()):
             self.heating_rate[varname] = self.state[varname] * 0.
 
     def _temperature_tendencies(self):
         self._compute_heating_rates()
         tendencies = {}
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             #C = self.state_domain[varname].heat_capacity
             C = value.domain.heat_capacity
             try:  # there may be state variables without heating rates
@@ -139,7 +139,7 @@ class ExternalEnergySource(EnergyBudget):
     """
     def __init__(self, **kwargs):
         super(ExternalEnergySource, self).__init__(**kwargs)
-        for varname in self.state.keys():
+        for varname in list(self.state.keys()):
             self.heating_rate[varname] = self.state[varname] * 0.
 
     def _compute_heating_rates(self):

--- a/climlab/process/energy_budget.py
+++ b/climlab/process/energy_budget.py
@@ -4,7 +4,7 @@ from climlab.process.time_dependent_process import TimeDependentProcess
 
 
 class EnergyBudget(TimeDependentProcess):
-    """A parent class for explicit energy budget processes.
+    r"""A parent class for explicit energy budget processes.
 
     This class solves equations that include a heat capacitiy term like
     :math:`C \\frac{dT}{dt} = \\textrm{flux convergence}`

--- a/climlab/process/implicit.py
+++ b/climlab/process/implicit.py
@@ -50,7 +50,7 @@ class ImplicitProcess(TimeDependentProcess):
         #adjustment = newstate.copy()
         adjustment = {}
         tendencies = {}
-        for name, var in self.state.iteritems():
+        for name, var in self.state.items():
             adjustment[name] = newstate[name] - var
             tendencies[name] = adjustment[name] / self.param['timestep']
         # express the adjustment (already accounting for the finite time step)

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -65,6 +65,7 @@
 
 from __future__ import division
 from __future__ import print_function
+from builtins import object
 import time, copy
 import numpy as np
 from climlab.domain.field import Field
@@ -135,7 +136,7 @@ class Process(object):
     def __str__(self):
         str1 = 'climlab Process of type {0}. \n'.format(type(self))
         str1 += 'State variables and domain shapes: \n'
-        for varname in self.state.keys():
+        for varname in list(self.state.keys()):
             str1 += '  {0}: {1} \n'.format(varname, self.domains[varname].shape)
         str1 += 'The subprocess tree: \n'
         str1 += walk.process_tree(self)
@@ -155,7 +156,7 @@ class Process(object):
         # dictionary of state variables (all of type Field)
         self.state = attr_dict.AttrDict()
         states = _make_dict(state, Field)
-        for name, value in states.iteritems():
+        for name, value in states.items():
             self.set_state(name, value)
         #convert int dtype to float
             if np.issubdtype(self.state[name].dtype, 'int'):
@@ -173,7 +174,7 @@ class Process(object):
             #self._input_vars = frozenset()
             self._input_vars = []
         else:
-            self.add_input(input.keys())
+            self.add_input(list(input.keys()))
             for name, var in input:
                 self.__dict__[name] = var
         self.creation_date = time.strftime("%a, %d %b %Y %H:%M:%S %z",
@@ -203,7 +204,7 @@ class Process(object):
         if isinstance(procdict, Process):
             self.add_subprocess('default', procdict)
         else:
-            for name, proc in procdict.iteritems():
+            for name, proc in procdict.items():
                 self.add_subprocess(name, proc)
 
     def add_subprocess(self, name, proc):
@@ -271,7 +272,7 @@ class Process(object):
             self.has_process_type_list = False
             # Add subprocess diagnostics to parent
             #  (if there are no name conflicts)
-            for diagname, value in proc.diagnostics.iteritems():
+            for diagname, value in proc.diagnostics.items():
                 if not (diagname in self.diagnostics or hasattr(self, diagname)):
                     self.add_diagnostic(diagname, value)
         else:
@@ -375,7 +376,7 @@ class Process(object):
                 raise ValueError('Shape mismatch between existing domain and new state variable.')
         # set the state dictionary
         self.state[name] = value
-        for name, value in self.state.iteritems():
+        for name, value in self.state.items():
         #convert int dtype to float
             if np.issubdtype(self.state[name].dtype, 'int'):
                 value = self.state[name].astype(float)
@@ -383,8 +384,8 @@ class Process(object):
         setattr(self, name, value)
 
     def _guess_state_domains(self):
-        for name, value in self.state.iteritems():
-            for domname, dom in self.domains.iteritems():
+        for name, value in self.state.items():
+            for domname, dom in self.domains.items():
                 if value.shape == dom.shape:
                     # same shape, assume it's the right domain
                     self.state_domain[name] = dom
@@ -536,7 +537,7 @@ class Process(object):
 
         """
         try:
-            for domname, dom in self.domains.iteritems():
+            for domname, dom in self.domains.items():
                 try:
                     thislat = dom.axes['lat'].points
                 except:
@@ -556,7 +557,7 @@ class Process(object):
 
         """
         try:
-            for domname, dom in self.domains.iteritems():
+            for domname, dom in self.domains.items():
                 try:
                     thislat = dom.axes['lat'].bounds
                 except:
@@ -576,7 +577,7 @@ class Process(object):
 
         """
         try:
-            for domname, dom in self.domains.iteritems():
+            for domname, dom in self.domains.items():
                 try:
                     thislon = dom.axes['lon'].points
                 except:
@@ -596,7 +597,7 @@ class Process(object):
 
         """
         try:
-            for domname, dom in self.domains.iteritems():
+            for domname, dom in self.domains.items():
                 try:
                     thislon = dom.axes['lon'].bounds
                 except:
@@ -616,7 +617,7 @@ class Process(object):
 
         """
         try:
-            for domname, dom in self.domains.iteritems():
+            for domname, dom in self.domains.items():
                 try:
                     thislev = dom.axes['lev'].points
                 except:
@@ -636,7 +637,7 @@ class Process(object):
 
         """
         try:
-            for domname, dom in self.domains.iteritems():
+            for domname, dom in self.domains.items():
                 try:
                     thislev = dom.axes['lev'].bounds
                 except:
@@ -656,7 +657,7 @@ class Process(object):
 
         """
         try:
-            for domname, dom in self.domains.iteritems():
+            for domname, dom in self.domains.items():
                 try:
                     thisdepth = dom.axes['depth'].points
                 except:
@@ -676,7 +677,7 @@ class Process(object):
 
         """
         try:
-            for domname, dom in self.domains.iteritems():
+            for domname, dom in self.domains.items():
                 try:
                     thisdepth = dom.axes['depth'].bounds
                 except:
@@ -755,7 +756,7 @@ def get_axes(process_or_domain):
         return dom.axes
     elif isinstance(dom, dict):
         axes = {}
-        for thisdom in dom.values():
+        for thisdom in list(dom.values()):
             assert isinstance(thisdom, _Domain)
             axes.update(thisdom.axes)
         return axes

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -64,6 +64,7 @@
 #==============================================================================
 
 from __future__ import division
+from __future__ import print_function
 import time, copy
 import numpy as np
 from climlab.domain.field import Field
@@ -321,7 +322,7 @@ class Process(object):
             self.subprocess.pop(name)
         except KeyError:
             if verbose:
-                print 'WARNING: {} not found in subprocess dictionary.'.format(name)
+                print('WARNING: {} not found in subprocess dictionary.'.format(name))
         self.has_process_type_list = False
 
     def set_state(self, name, value):
@@ -495,7 +496,7 @@ class Process(object):
             delattr(self, name)
             self._diag_vars.remove(name)
         except:
-            print 'No diagnostic named {} was found.'.format(name)
+            print('No diagnostic named {} was found.'.format(name))
 
     @property
     def diagnostics(self):

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 import numpy as np
 import copy
 from climlab import constants as const

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import print_function
+from builtins import str
+from builtins import range
 import numpy as np
 import copy
 from climlab import constants as const
@@ -64,7 +66,7 @@ class TimeDependentProcess(Process):
         # Create the state dataset
         super(TimeDependentProcess, self).__init__(**kwargs)
         self.tendencies = {}
-        for name, var in self.state.iteritems():
+        for name, var in self.state.items():
             self.tendencies[name] = var * 0.
         self.timeave = {}
         if timestep is None:
@@ -172,11 +174,11 @@ class TimeDependentProcess(Process):
         #  Tendencies due to implicit and adjustment processes need to be
         #  calculated from a state that is already adjusted after explicit stuff
         #  So apply the tendencies temporarily and then remove them again
-        for name, var in self.state.iteritems():
+        for name, var in self.state.items():
             var += tendencies_explicit[name] * self.timestep
         # Now compute all implicit processes -- matrix inversions
         tendencies_implicit = self._compute_type('implicit')
-        for name, var in self.state.iteritems():
+        for name, var in self.state.items():
             var += tendencies_implicit[name] * self.timestep
         # Finally compute all instantaneous adjustments
         #  and express in terms of discrete timestep
@@ -185,7 +187,7 @@ class TimeDependentProcess(Process):
         for name in adjustments:
             tendencies_adjustment[name] = adjustments[name] / self.timestep
         #  Now remove the changes from the model state
-        for name, var in self.state.iteritems():
+        for name, var in self.state.items():
             var -= ( (tendencies_implicit[name] + tendencies_explicit[name]) *
                     self.timestep)
         # Finally sum up all the tendencies from all processes
@@ -211,7 +213,7 @@ class TimeDependentProcess(Process):
             tendencies[varname] = 0. * self.state[varname]
         for proc in self.process_types[proctype]:
             proc.tendencies = proc._compute()
-            for varname, tend in proc.tendencies.iteritems():
+            for varname, tend in proc.tendencies.items():
                 tendencies[varname] += tend
         return tendencies
 
@@ -220,7 +222,7 @@ class TimeDependentProcess(Process):
         #  needs to be implemented for each daughter class
         #  needs to return a dictionary with same keys as self.state
         tendencies = {}
-        for name, value in self.state.iteritems():
+        for name, value in self.state.items():
             tendencies[name] = value * 0.
         return tendencies
 
@@ -273,14 +275,14 @@ class TimeDependentProcess(Process):
         self.compute()
         #  Total tendency is applied as an explicit forward timestep
         # (already accounting properly for order of operations in compute() )
-        for name, var in self.state.iteritems():
+        for name, var in self.state.items():
             var += self.tendencies[name] * self.timestep
 
         # Update all time counters for this and all subprocesses in the tree
         #  Also pass diagnostics up the process tree
         for name, proc, level in walk_processes(self, ignoreFlag=True):
             proc._update_time()
-            for diagname, value in proc.diagnostics.iteritems():
+            for diagname, value in proc.diagnostics.items():
                 self.__setattr__(diagname, value)
 
     def compute_diagnostics(self, num_iter=3):
@@ -294,7 +296,7 @@ class TimeDependentProcess(Process):
             self.compute()
         #  Pass diagnostics up the process tree
         for name, proc, level in walk_processes(self, ignoreFlag=True):
-            for diagname, value in proc.diagnostics.iteritems():
+            for diagname, value in proc.diagnostics.items():
                 self.__setattr__(diagname, value)
 
     def _update_time(self):
@@ -371,14 +373,14 @@ class TimeDependentProcess(Process):
                 # add any new diagnostics to the timeave dictionary
                 self.timeave.update(self.diagnostics)
                 # reset all values to zero
-                for varname, value in self.timeave.iteritems():
+                for varname, value in self.timeave.items():
                 # moves on to the next varname if value is None
                 # this preserves NoneType diagnostics
                     if value is None:
                         continue
                     self.timeave[varname] = 0*value
             # adding up all values for each timestep
-            for varname in self.timeave.keys():
+            for varname in list(self.timeave.keys()):
                 try:
                     self.timeave[varname] += self.state[varname]
                 except:
@@ -386,7 +388,7 @@ class TimeDependentProcess(Process):
                         self.timeave[varname] += self.diagnostics[varname]
                     except: pass
         # calculating mean values through dividing the sum by number of steps
-        for varname, value in self.timeave.iteritems():
+        for varname, value in self.timeave.items():
             if value is None:
                 continue
             self.timeave[varname] /= numsteps
@@ -453,7 +455,7 @@ class TimeDependentProcess(Process):
 
         """
         # implemented by m-kreuzer
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             value_old = copy.deepcopy(value)
             self.integrate_years(1,verbose=False)
             while np.max(np.abs(value_old-value)) > crit :

--- a/climlab/radiation/__init__.py
+++ b/climlab/radiation/__init__.py
@@ -2,12 +2,13 @@
 Modules for radiative transfer in vertical columns,
 along with processes for insolation and fixed relative humidity.
 '''
+from __future__ import absolute_import
 
-from aplusbt import AplusBT, AplusBT_CO2
-from boltzmann import Boltzmann
-from insolation import FixedInsolation, P2Insolation, AnnualMeanInsolation, DailyInsolation
-from nband import NbandRadiation, ThreeBandSW
-from water_vapor import ManabeWaterVapor
+from .aplusbt import AplusBT, AplusBT_CO2
+from .boltzmann import Boltzmann
+from .insolation import FixedInsolation, P2Insolation, AnnualMeanInsolation, DailyInsolation
+from .nband import NbandRadiation, ThreeBandSW
+from .water_vapor import ManabeWaterVapor
 #from radiation import Radiation, Radiation_SW, Radiation_LW
-from cam3 import CAM3, CAM3_LW, CAM3_SW
-from rrtm import RRTMG, RRTMG_LW, RRTMG_SW
+from .cam3 import CAM3, CAM3_LW, CAM3_SW
+from .rrtm import RRTMG, RRTMG_LW, RRTMG_SW

--- a/climlab/radiation/aplusbt.py
+++ b/climlab/radiation/aplusbt.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 class AplusBT(EnergyBudget):
-    """The simplest linear longwave radiation module.
+    r"""The simplest linear longwave radiation module.
 
     Calculates the Outgoing Longwave Radation (OLR) :math:`R\uparrow` as
 

--- a/climlab/radiation/aplusbt.py
+++ b/climlab/radiation/aplusbt.py
@@ -147,13 +147,13 @@ class AplusBT(EnergyBudget):
         self.param['B'] = value
 
     def _compute_emission(self):
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             self.OLR[:] = self.A + self.B * value
 
     def _compute_heating_rates(self):
         '''Compute energy flux convergences to get heating rates in :math:`W/m^2`,'''
         self._compute_emission()
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             self.heating_rate[varname] = -self.OLR
 
 
@@ -314,11 +314,11 @@ class AplusBT_CO2(EnergyBudget):
         l = np.log(self.CO2/300.)
         self.A = -326.400 + 9.16100*l - 3.16400*l**2 + 0.546800*l**3
         self.B =    1.953 - 0.04866*l + 0.01309*l**2 - 0.002577*l**3
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             self.OLR[:] = self.A + self.B * (value + const.tempCtoK)
 
     def _compute_heating_rates(self):
         """Computes energy flux convergences to get heating rates in :math:`W/m^2`."""
         self._compute_emission()
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             self.heating_rate[varname] = -self.OLR

--- a/climlab/radiation/boltzmann.py
+++ b/climlab/radiation/boltzmann.py
@@ -4,7 +4,7 @@ from climlab.process.energy_budget import EnergyBudget
 
 
 class Boltzmann(EnergyBudget):
-    """A class for black body radiation.
+    r"""A class for black body radiation.
 
     Implements a radiation subprocess which computes longwave radiation
     with the Stefan-Boltzmann law for black/grey body radiation.

--- a/climlab/radiation/boltzmann.py
+++ b/climlab/radiation/boltzmann.py
@@ -185,7 +185,7 @@ class Boltzmann(EnergyBudget):
 #            self.diagnostics['OLR'] = self.OLR
 
     def _compute_emission(self):
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             flux = self.eps * self.tau * const.sigma * (value + const.tempCtoK)**4.
             self.OLR[:] = flux
 
@@ -195,5 +195,5 @@ class Boltzmann(EnergyBudget):
 
         """
         self._compute_emission()
-        for varname, value in self.state.iteritems():
+        for varname, value in self.state.items():
             self.heating_rate[varname] = -self.OLR

--- a/climlab/radiation/cam3/__init__.py
+++ b/climlab/radiation/cam3/__init__.py
@@ -1,1 +1,2 @@
-from cam3 import CAM3, CAM3_LW, CAM3_SW
+from __future__ import absolute_import
+from .cam3 import CAM3, CAM3_LW, CAM3_SW

--- a/climlab/radiation/cam3/cam3.py
+++ b/climlab/radiation/cam3/cam3.py
@@ -29,8 +29,7 @@ climlab wrappers for the NCAR CAM3 radiation code
 
 
 '''
-from __future__ import division
-from __future__ import print_function
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from climlab import constants as const
 from climlab.utils.thermo import vmr_to_mmr
@@ -38,7 +37,7 @@ from climlab.radiation.radiation import _Radiation_SW, _Radiation_LW
 import os
 #  Wrapping these imports in try/except to avoid failures during documentation building on readthedocs
 try:
-    import _cam3
+    from . import _cam3
 except:
     print('Cannot import compiled Fortran extension, CAM3 module will not be functional.')
 try:

--- a/climlab/radiation/cam3/cam3.py
+++ b/climlab/radiation/cam3/cam3.py
@@ -30,6 +30,7 @@ climlab wrappers for the NCAR CAM3 radiation code
 
 '''
 from __future__ import division
+from __future__ import print_function
 import numpy as np
 from climlab import constants as const
 from climlab.utils.thermo import vmr_to_mmr
@@ -39,11 +40,11 @@ import os
 try:
     import _cam3
 except:
-    print 'Cannot import compiled Fortran extension, CAM3 module will not be functional.'
+    print('Cannot import compiled Fortran extension, CAM3 module will not be functional.')
 try:
     import netCDF4 as nc
 except:
-    print 'Cannot import netCDF4 interface. Will not be able to properly initialize the CAM3 module.'
+    print('Cannot import netCDF4 interface. Will not be able to properly initialize the CAM3 module.')
 
 
 def init_cam3(mod):
@@ -64,7 +65,7 @@ def init_cam3(mod):
 try:
     init_cam3(_cam3.absems)
 except:
-    print 'Cannot initialize the CAM3 module.'
+    print('Cannot initialize the CAM3 module.')
 
 class CAM3(_Radiation_SW, _Radiation_LW):
     '''

--- a/climlab/radiation/cam3/setup.py
+++ b/climlab/radiation/cam3/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from os.path import join, abspath
 
 
@@ -20,7 +21,7 @@ def configuration(parent_package='', top_path=None):
         #  Suppress all compiler warnings (avoid huge CI log files)
         f90flags.append('-w')
     except CompilerNotFound:
-        print 'No Fortran compiler found, not building the CAM3 radiation module!'
+        print('No Fortran compiler found, not building the CAM3 radiation module!')
         build = False
 
     config = Configuration(package_name='cam3', parent_name=parent_package, top_path=top_path)
@@ -67,7 +68,7 @@ def cam3_gen_source(ext, build_dir):
         config.have_f90c()
         return sourcelist
     except:
-        print 'No Fortran 90 compiler found, not building CAM3 extension!'
+        print('No Fortran 90 compiler found, not building CAM3 extension!')
         return None
 
 if __name__ == '__main__':

--- a/climlab/radiation/greygas.py
+++ b/climlab/radiation/greygas.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import range
 import numpy as np
 from climlab.utils.thermo import blackbody_emission
 from climlab.radiation.transmissivity import Transmissivity

--- a/climlab/radiation/nband.py
+++ b/climlab/radiation/nband.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import range
 import numpy as np
 from climlab.radiation.greygas import GreyGas
 from climlab import constants as const
@@ -66,7 +67,7 @@ class NbandRadiation(GreyGas):
         # this will cause a problem for a model without CO2
         tau = np.zeros_like(self.absorber_vmr['CO2']*
                             self.absorption_cross_section['CO2'])
-        for gas, vmr in self.absorber_vmr.iteritems():
+        for gas, vmr in self.absorber_vmr.items():
             # convert to mass of absorber per unit total mass
             if gas is 'H2O':  # H2O is stored as specific humidity, not VMR
                 q = vmr

--- a/climlab/radiation/radiation.py
+++ b/climlab/radiation/radiation.py
@@ -69,6 +69,7 @@ Longwave processes compute these diagnostics (minimum):
 '''
 
 from __future__ import division
+from __future__ import print_function
 import numpy as np
 from climlab.process import EnergyBudget
 from climlab.radiation import ManabeWaterVapor
@@ -78,7 +79,7 @@ from climlab import constants as const
 try:
     import netCDF4 as nc
 except:
-    print 'Cannot import netCDF4 interface. Will not be able to initialize ozone from data file.'
+    print('Cannot import netCDF4 interface. Will not be able to initialize ozone from data file.')
 
 
 def default_specific_humidity(Tatm):
@@ -130,7 +131,7 @@ def default_absorbers(Tatm,
     ozonefilepath = os.path.join(datadir, ozone_file)
     #  Open the ozone data file
     if verbose:
-        print 'Getting ozone data from', ozonefilepath
+        print('Getting ozone data from', ozonefilepath)
     ozonedata = nc.Dataset(ozonefilepath)
     ozone_lev = ozonedata.variables['lev'][:]
     ozone_lat = ozonedata.variables['lat'][:]
@@ -151,8 +152,8 @@ def default_absorbers(Tatm,
             f2d = interp2d(ozone_lat, ozone_lev, ozone_zon)
             absorber_vmr['O3'] = f2d(lat, lev).transpose()
         except:
-            print 'Interpolation of ozone data failed.'
-            print 'Reverting to default O3.'
+            print('Interpolation of ozone data failed.')
+            print('Reverting to default O3.')
             absorber_vmr['O3'] = np.zeros_like(Tatm)
     return absorber_vmr
 

--- a/climlab/radiation/rrtm/__init__.py
+++ b/climlab/radiation/rrtm/__init__.py
@@ -34,8 +34,7 @@ See <http://rtweb.aer.com/rrtm_frame.html> for more information about the RRTMG 
             print rcm.ASR - rcm.OLR
 
 '''
-from __future__ import division
-from __future__ import absolute_import
+from __future__ import division, absolute_import
 from .rrtmg import RRTMG
 from .rrtmg_lw import RRTMG_LW
 from .rrtmg_sw import RRTMG_SW

--- a/climlab/radiation/rrtm/__init__.py
+++ b/climlab/radiation/rrtm/__init__.py
@@ -35,7 +35,8 @@ See <http://rtweb.aer.com/rrtm_frame.html> for more information about the RRTMG 
 
 '''
 from __future__ import division
-from rrtmg import RRTMG
-from rrtmg_lw import RRTMG_LW
-from rrtmg_sw import RRTMG_SW
-from utils import _climlab_to_rrtm, _rrtm_to_climlab
+from __future__ import absolute_import
+from .rrtmg import RRTMG
+from .rrtmg_lw import RRTMG_LW
+from .rrtmg_sw import RRTMG_SW
+from .utils import _climlab_to_rrtm, _rrtm_to_climlab

--- a/climlab/radiation/rrtm/_rrtmg_lw/__init__.py
+++ b/climlab/radiation/rrtm/_rrtmg_lw/__init__.py
@@ -1,2 +1,3 @@
+from __future__ import absolute_import
 #  import everything from the fortran object
-from _rrtmg_lw import *
+from ._rrtmg_lw import *

--- a/climlab/radiation/rrtm/_rrtmg_lw/setup.py
+++ b/climlab/radiation/rrtm/_rrtmg_lw/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from os.path import join, abspath
 
 
@@ -22,7 +23,7 @@ def configuration(parent_package='', top_path=None):
         #  Suppress all compiler warnings (avoid huge CI log files)
         f90flags.append('-w')
     except CompilerNotFound:
-        print 'No Fortran compiler found, not building the RRTMG_LW radiation module!'
+        print('No Fortran compiler found, not building the RRTMG_LW radiation module!')
         build = False
 
     config = Configuration(package_name='_rrtmg_lw', parent_name=parent_package, top_path=top_path)
@@ -90,7 +91,7 @@ def rrtmg_lw_gen_source(ext, build_dir):
         config.have_f90c()
         return sourcelist
     except:
-        print 'No Fortran 90 compiler found, not building RRTMG_LW extension!'
+        print('No Fortran 90 compiler found, not building RRTMG_LW extension!')
         return None
 
 if __name__ == '__main__':

--- a/climlab/radiation/rrtm/_rrtmg_sw/__init__.py
+++ b/climlab/radiation/rrtm/_rrtmg_sw/__init__.py
@@ -1,2 +1,3 @@
+from __future__ import absolute_import
 #  import everything from the fortran object
-from _rrtmg_sw import *
+from ._rrtmg_sw import *

--- a/climlab/radiation/rrtm/_rrtmg_sw/setup.py
+++ b/climlab/radiation/rrtm/_rrtmg_sw/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from os.path import join, abspath
 
 
@@ -22,7 +23,7 @@ def configuration(parent_package='', top_path=None):
         #  Suppress all compiler warnings (avoid huge CI log files)
         f90flags.append('-w')
     except CompilerNotFound:
-        print 'No Fortran compiler found, not building the RRTMG_SW radiation module!'
+        print('No Fortran compiler found, not building the RRTMG_SW radiation module!')
         build = False
 
     config = Configuration(package_name='_rrtmg_sw', parent_name=parent_package, top_path=top_path)
@@ -91,7 +92,7 @@ def rrtmg_sw_gen_source(ext, build_dir):
         config.have_f90c()
         return sourcelist
     except:
-        print 'No Fortran 90 compiler found, not building RRTMG_LW extension!'
+        print('No Fortran 90 compiler found, not building RRTMG_LW extension!')
         return None
 
 if __name__ == '__main__':

--- a/climlab/radiation/rrtm/rrtmg.py
+++ b/climlab/radiation/rrtm/rrtmg.py
@@ -1,9 +1,10 @@
 from __future__ import division
+from __future__ import absolute_import
 import numpy as np
 from climlab import constants as const
 from climlab.radiation.radiation import _Radiation_SW, _Radiation_LW
-from rrtmg_lw import RRTMG_LW
-from rrtmg_sw import RRTMG_SW, nbndsw
+from .rrtmg_lw import RRTMG_LW
+from .rrtmg_sw import RRTMG_SW, nbndsw
 
 
 class RRTMG(_Radiation_SW, _Radiation_LW):

--- a/climlab/radiation/rrtm/rrtmg_lw.py
+++ b/climlab/radiation/rrtm/rrtmg_lw.py
@@ -1,20 +1,22 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import numpy as np
 from climlab import constants as const
 from climlab.radiation.radiation import _Radiation_LW
-from utils import _prepare_general_arguments
-from utils import _climlab_to_rrtm, _climlab_to_rrtm_sfc, _rrtm_to_climlab
+from .utils import _prepare_general_arguments
+from .utils import _climlab_to_rrtm, _climlab_to_rrtm_sfc, _rrtm_to_climlab
 # These values will get overridden by reading from Fortran extension
 nbndlw = 1; ngptlw = 1;
 try:
     #  The compiled fortran extension module
-    import _rrtmg_lw
+    from . import _rrtmg_lw
     nbndlw = int(_rrtmg_lw.parrrtm.nbndlw)
     ngptlw = int(_rrtmg_lw.parrrtm.ngptlw)
     #  Initialize absorption data
     _rrtmg_lw.climlab_rrtmg_lw_ini(const.cp)
 except:
-    print 'Cannot import and initialize compiled Fortran extension, RRTMG_LW module will not be functional.'
+    print('Cannot import and initialize compiled Fortran extension, RRTMG_LW module will not be functional.')
 
 
 class RRTMG_LW(_Radiation_LW):

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -1,21 +1,23 @@
 from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
 import numpy as np
 from climlab import constants as const
 from climlab.radiation.radiation import _Radiation_SW
-from utils import _prepare_general_arguments
-from utils import _climlab_to_rrtm, _climlab_to_rrtm_sfc, _rrtm_to_climlab
+from .utils import _prepare_general_arguments
+from .utils import _climlab_to_rrtm, _climlab_to_rrtm_sfc, _rrtm_to_climlab
 # These values will get overridden by reading from Fortran extension
 nbndsw = 1; naerec = 1; ngptsw = 1;
 try:
     #  The compiled fortran extension module
-    import _rrtmg_sw
+    from . import _rrtmg_sw
     nbndsw = int(_rrtmg_sw.parrrsw.nbndsw)
     naerec = int(_rrtmg_sw.parrrsw.naerec)
     ngptsw = int(_rrtmg_sw.parrrsw.ngptsw)
     #  Initialize absorption data
     _rrtmg_sw.climlab_rrtmg_sw_ini(const.cp)
 except:
-    print 'Cannot import and initialize compiled Fortran extension, RRTMG_SW module will not be functional.'
+    print('Cannot import and initialize compiled Fortran extension, RRTMG_SW module will not be functional.')
 
 
 class RRTMG_SW(_Radiation_SW):

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -1,6 +1,4 @@
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
+from __future__ import division, print_function, absolute_import
 import numpy as np
 from climlab import constants as const
 from climlab.radiation.radiation import _Radiation_SW

--- a/climlab/radiation/transmissivity.py
+++ b/climlab/radiation/transmissivity.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import object
 import numpy as np
 # experimental...  this is not well documented!
 from numpy.core.umath_tests import matrix_multiply

--- a/climlab/solar/orbital.py
+++ b/climlab/solar/orbital.py
@@ -17,6 +17,7 @@ See http://vo.imcce.fr/insola/earth/online/earth/La2004/README.TXT
 
 """
 from __future__ import division
+from __future__ import print_function
 import numpy as np
 from scipy import interpolate
 import os
@@ -106,16 +107,16 @@ class OrbitalTable:
         fullfilename = os.path.join(os.path.dirname(__file__), past_file)
         try:
             record = open(fullfilename,'r')
-            print 'Loading Berger and Loutre (1991) orbital parameter data from file ' + fullfilename
+            print('Loading Berger and Loutre (1991) orbital parameter data from file ' + fullfilename)
         except:
-            print 'Failed to load orbital locally, trying to access it via remote ftp.'
+            print('Failed to load orbital locally, trying to access it via remote ftp.')
             try:
                 import urllib2
                 record = urllib2.urlopen( base_url + past_file )
-                print 'Accessing Berger and Loutre (1991) orbital data from ' + base_url
-                print 'Reading file ' + past_file
+                print('Accessing Berger and Loutre (1991) orbital data from ' + base_url)
+                print('Reading file ' + past_file)
             except:
-                raise StandardError('Failed to load the data via remote ftp.')
+                raise Exception('Failed to load the data via remote ftp.')
 
         #  loop through each line of the file, read it into numpy array
         #  skip first three lines of header
@@ -162,13 +163,13 @@ class LongOrbitalTable(OrbitalTable):
         data_past = np.empty((num_lines_past,num_columns))
         data_future = np.empty((num_lines_future, num_columns))
 
-        print 'Attempting to access La2004 orbital data from ' + base_url
+        print('Attempting to access La2004 orbital data from ' + base_url)
         #  loop through each line of the file, read it into numpy array
         for (data,filename) in zip((data_past,data_future),
                             (past_file,future_file)):
             try:
                 import urllib2
-                print 'Reading file ' + filename
+                print('Reading file ' + filename)
                 record = urllib2.urlopen( base_url + filename )
                 for index,line in enumerate(record):
                     str1 = line.rstrip()  # remove newline character
@@ -176,7 +177,7 @@ class LongOrbitalTable(OrbitalTable):
                     data[index,:] = np.fromstring(str2, sep=' ')
                 record.close()
             except:
-                raise StandardError('Failed to access file ' + filename )
+                raise Exception('Failed to access file ' + filename )
 
         #  need to flip it so the data runs from past to present
         data_past = np.flipud(data_past)

--- a/climlab/solar/orbital.py
+++ b/climlab/solar/orbital.py
@@ -16,13 +16,10 @@ A subclass :class:`LongOrbitalTable()` works with La2004 orbital data for
 See http://vo.imcce.fr/insola/earth/online/earth/La2004/README.TXT
 
 """
-from __future__ import division
-from __future__ import print_function
+from __future__ import division, print_function
 from future import standard_library
 standard_library.install_aliases()
-from builtins import zip
-from builtins import range
-from builtins import object
+from builtins import zip, range, object
 import numpy as np
 from scipy import interpolate
 import os
@@ -177,7 +174,7 @@ class LongOrbitalTable(OrbitalTable):
                 print('Reading file ' + filename)
                 record = urllib.request.urlopen( base_url + filename )
                 for index,line in enumerate(record):
-                    str1 = line.rstrip()  # remove newline character
+                    str1 = str(line.rstrip(),'utf-8')  # remove newline character
                     str2 = str1.replace('D','E')  # put string into numpy format
                     data[index,:] = np.fromstring(str2, sep=' ')
                 record.close()

--- a/climlab/solar/orbital.py
+++ b/climlab/solar/orbital.py
@@ -18,11 +18,16 @@ See http://vo.imcce.fr/insola/earth/online/earth/La2004/README.TXT
 """
 from __future__ import division
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from builtins import range
+from builtins import object
 import numpy as np
 from scipy import interpolate
 import os
 
-class OrbitalTable:
+class OrbitalTable(object):
     """Invoking OrbitalTable() will load 5 million years of orbital data
     from :cite:`Berger_1991` and compute linear interpolants.
 
@@ -111,8 +116,8 @@ class OrbitalTable:
         except:
             print('Failed to load orbital locally, trying to access it via remote ftp.')
             try:
-                import urllib2
-                record = urllib2.urlopen( base_url + past_file )
+                import urllib.request, urllib.error, urllib.parse
+                record = urllib.request.urlopen( base_url + past_file )
                 print('Accessing Berger and Loutre (1991) orbital data from ' + base_url)
                 print('Reading file ' + past_file)
             except:
@@ -168,9 +173,9 @@ class LongOrbitalTable(OrbitalTable):
         for (data,filename) in zip((data_past,data_future),
                             (past_file,future_file)):
             try:
-                import urllib2
+                import urllib.request, urllib.error, urllib.parse
                 print('Reading file ' + filename)
-                record = urllib2.urlopen( base_url + filename )
+                record = urllib.request.urlopen( base_url + filename )
                 for index,line in enumerate(record):
                     str1 = line.rstrip()  # remove newline character
                     str2 = str1.replace('D','E')  # put string into numpy format

--- a/climlab/solar/orbital_cycles.py
+++ b/climlab/solar/orbital_cycles.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 import numpy as np
 from climlab import constants as const
 from climlab.solar.orbital import OrbitalTable

--- a/climlab/solar/orbital_cycles.py
+++ b/climlab/solar/orbital_cycles.py
@@ -1,12 +1,15 @@
 from __future__ import division
 from __future__ import print_function
+from builtins import str
+from builtins import range
+from builtins import object
 import numpy as np
 from climlab import constants as const
 from climlab.solar.orbital import OrbitalTable
 from climlab.domain.field import global_mean
 
 
-class OrbitalCycles:
+class OrbitalCycles(object):
     def __init__(self,
                  model,
                  kyear_start=-20.,

--- a/climlab/surface/__init__.py
+++ b/climlab/surface/__init__.py
@@ -1,3 +1,4 @@
 '''Modules for surface processes in climlab.'''
-from turbulent import SensibleHeatFlux, LatentHeatFlux
-from albedo import ConstantAlbedo, P2Albedo, Iceline, StepFunctionAlbedo
+from __future__ import absolute_import
+from .turbulent import SensibleHeatFlux, LatentHeatFlux
+from .albedo import ConstantAlbedo, P2Albedo, Iceline, StepFunctionAlbedo

--- a/climlab/surface/albedo.py
+++ b/climlab/surface/albedo.py
@@ -41,7 +41,7 @@ class ConstantAlbedo(DiagnosticProcess):
     def __init__(self, albedo=0.33, **kwargs):
         '''Uniform prescribed albedo.'''
         super(ConstantAlbedo, self).__init__(**kwargs)
-        dom = self.domains.itervalues().next()
+        dom = next(self.domains.itervalues())
         self.add_diagnostic('albedo', Field(albedo, domain=dom))
         #self.albedo = albedo
 
@@ -189,7 +189,7 @@ class P2Albedo(DiagnosticProcess):
         # make sure that the diagnostic has the correct field dimensions.
         #dom = self.domains['default']
         #  this is a more robust way to get the single value from dictionary:
-        dom = self.domains.itervalues().next()
+        dom = next(self.domains.itervalues())
         self.albedo = Field(albedo, domain=dom)
 
 

--- a/climlab/surface/albedo.py
+++ b/climlab/surface/albedo.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from builtins import next
 import numpy as np
 from climlab.process.diagnostic import DiagnosticProcess
 from climlab.utils.legendre import P2
@@ -41,7 +42,7 @@ class ConstantAlbedo(DiagnosticProcess):
     def __init__(self, albedo=0.33, **kwargs):
         '''Uniform prescribed albedo.'''
         super(ConstantAlbedo, self).__init__(**kwargs)
-        dom = next(self.domains.itervalues())
+        dom = next(iter(self.domains.values()))
         self.add_diagnostic('albedo', Field(albedo, domain=dom))
         #self.albedo = albedo
 
@@ -189,7 +190,7 @@ class P2Albedo(DiagnosticProcess):
         # make sure that the diagnostic has the correct field dimensions.
         #dom = self.domains['default']
         #  this is a more robust way to get the single value from dictionary:
-        dom = next(self.domains.itervalues())
+        dom = next(iter(self.domains.values()))
         self.albedo = Field(albedo, domain=dom)
 
 

--- a/climlab/tests/test_bandrc.py
+++ b/climlab/tests/test_bandrc.py
@@ -2,8 +2,6 @@ from __future__ import division
 import numpy as np
 import climlab
 import pytest
-from climlab.surface.turbulent import SensibleHeatFlux, LatentHeatFlux
-from climlab.convection.convadj import ConvectiveAdjustment
 
 # The fixtures are reusable pieces of code to set up the input to the tests.
 # Without fixtures, we would have to do a lot of cutting and pasting
@@ -14,20 +12,21 @@ def model():
     return climlab.BandRCModel()
 
 @pytest.fixture()
-def diffmodel(model):
+def diffmodel():
     ''' 2D radiative-convective model with band radiation including water vapor,
     fixed relative humidity, meridional heat transport (diffusion) and convective adjustment.
     '''
     diffmodel = climlab.BandRCModel(num_lev=30, num_lat=90)
-    insolation = climlab.radiation.insolation.AnnualMeanInsolation(domains=diffmodel.Ts.domain)
+    insolation = climlab.radiation.AnnualMeanInsolation(domains=diffmodel.Ts.domain)
     diffmodel.add_subprocess('insolation', insolation)
-    diffmodel.subprocess.SW.flux_from_space = diffmodel.subprocess.insolation.insolation
+    diffmodel.subprocess.SW.flux_from_space = insolation.insolation
     # thermal diffusivity in W/m**2/degC
     D = 0.05
     # meridional diffusivity in 1/s
     K = D / diffmodel.Tatm.domain.heat_capacity[0]
-    d = climlab.dynamics.diffusion.MeridionalDiffusion(K=K,
-                state={'Tatm': diffmodel.state['Tatm']}, **diffmodel.param)
+    d = climlab.dynamics.MeridionalDiffusion(K=K,
+                state={'Tatm': diffmodel.state['Tatm']},
+                **diffmodel.param)
     diffmodel.add_subprocess('diffusion', d)
     return diffmodel
 
@@ -36,15 +35,15 @@ def diffmodel_surfflux(diffmodel):
     '''Explicit surface sensible and latent heat fluxes.'''
     diffmodel_surfflux = climlab.process_like(diffmodel)
     # process models for surface heat fluxes
-    shf = SensibleHeatFlux(state=diffmodel_surfflux.state, Cd=0.5E-3)
-    lhf = LatentHeatFlux(state=diffmodel_surfflux.state, Cd=0.5E-3)
+    shf = climlab.surface.SensibleHeatFlux(state=diffmodel_surfflux.state, Cd=0.5E-3)
+    lhf = climlab.surface.LatentHeatFlux(state=diffmodel_surfflux.state, Cd=0.5E-3)
     # set the water vapor input field for LHF
     lhf.q = diffmodel_surfflux.q
     diffmodel_surfflux.add_subprocess('SHF', shf)
     diffmodel_surfflux.add_subprocess('LHF', lhf)
     #  Convective adjustment for atmosphere only
     diffmodel_surfflux.remove_subprocess('convective adjustment')
-    conv = ConvectiveAdjustment(state={'Tatm':diffmodel_surfflux.state['Tatm']},
+    conv = climlab.convection.ConvectiveAdjustment(state={'Tatm':diffmodel_surfflux.state['Tatm']},
                                 **diffmodel_surfflux.param)
     diffmodel_surfflux.add_subprocess('convective adjustment', conv)
     return diffmodel_surfflux
@@ -55,10 +54,25 @@ def _check_minmax(array, amin, amax):
     return (np.allclose(array.min(), amin) and
             np.allclose(array.max(), amax))
 
+@pytest.mark.fast
 def test_model_creation(model):
     """Just make sure we can create a model."""
     assert len(model.Tatm)==30
 
+@pytest.mark.fast
+def test_diffmodel(diffmodel):
+    """Check that we can integrate the model with diffusion."""
+    diffmodel.step_forward()
+    diffmodel.integrate_days(2)
+    #  Would be better to have these tests evaluate a numerical condition
+
+@pytest.mark.fast
+def test_diffmodel_surfflux(diffmodel_surfflux):
+    """Check that we can integrate the model with diffusion."""
+    diffmodel_surfflux.step_forward()
+    diffmodel_surfflux.integrate_days(2)
+
+@pytest.mark.slow
 def test_integrate_years(model):
     """Check that we can integrate forward the model and get the expected
     surface temperature and water vapor.
@@ -71,14 +85,3 @@ def test_integrate_years(model):
     model.absorber_vmr['CO2'] *= 2.
     model.integrate_years(2)
     assert np.isclose(model.Ts - Ts, 3.180993)
-
-def test_diffmodel(diffmodel):
-    """Check that we can integrate the model with diffusion."""
-    diffmodel.step_forward()
-    diffmodel.integrate_days(30)
-    #  Would be better to have these tests evaluate a numerical condition
-
-def test_diffmodel_surfflux(diffmodel_surfflux):
-    """Check that we can integrate the model with diffusion."""
-    diffmodel_surfflux.step_forward()
-    diffmodel_surfflux.integrate_days(30)

--- a/climlab/tests/test_cam3rad.py
+++ b/climlab/tests/test_cam3rad.py
@@ -19,14 +19,14 @@ def rcm():
     convadj = climlab.convection.ConvectiveAdjustment(state=state,
                                                       adj_lapse_rate=6.5)
     # CAM3 radiation with default parameters and interactive water vapor
-    #rad = climlab.radiation.CAM3(state=state, albedo=alb, specific_humidity=h2o.q)
-    rad = climlab.radiation.CAM3(state=state, albedo=alb)
+    rad = climlab.radiation.CAM3(state=state, albedo=alb, specific_humidity=h2o.q)
     # Couple the models
     rcm.add_subprocess('Radiation', rad)
     rcm.add_subprocess('ConvectiveAdjustment', convadj)
     rcm.add_subprocess('H2O', h2o)
     return rcm
 
+@pytest.mark.fast
 def test_rce(rcm):
     '''Test a single-column radiative-convective model with CAM3 radiation and
     fixed relative humidity.'''
@@ -36,6 +36,7 @@ def test_rce(rcm):
     #rcm.integrate_years(5)
     #assert(np.isclose(rcm.Ts, ))
 
+@pytest.mark.slow
 def test_re_radiative_forcing():
     state = climlab.column_state(num_lev=num_lev)
     rad = climlab.radiation.CAM3(state=state)
@@ -46,6 +47,7 @@ def test_re_radiative_forcing():
     rad2.compute_diagnostics()
     assert (rad2.ASR - rad2.OLR) > 1.  # positive radiative forcing
 
+@pytest.mark.slow
 def test_rce_radiative_forcing(rcm):
     '''Run a single-column radiative-convective model with CAM3 radiation
     out to equilibrium. Clone the model, double CO2 and measure the instantaneous
@@ -57,6 +59,7 @@ def test_rce_radiative_forcing(rcm):
     rcm2.compute_diagnostics()
     assert (rcm2.ASR - rcm2.OLR) > 1.  # positive radiative forcing
 
+@pytest.mark.fast
 def test_cam3_multidim():
     state = climlab.column_state(num_lev=40, num_lat=3, water_depth=5.)
     rad = climlab.radiation.CAM3(state=state)

--- a/climlab/tests/test_domain2D.py
+++ b/climlab/tests/test_domain2D.py
@@ -1,19 +1,20 @@
 from __future__ import division
 import numpy as np
 import climlab
-from climlab import domain
 import pytest
 
+@pytest.mark.fast
 def test_state():
     initialT0 = 15.
-    sfc = domain.surface_2D(num_lat=90, num_lon=180)
-    sfc = domain.surface_2D(lat=([-90.,0.,90.]),
+    sfc = climlab.domain.surface_2D(num_lat=90, num_lon=180)
+    sfc = climlab.domain.surface_2D(lat=([-90.,0.,90.]),
                             lon=([-180.,0.,180.]))
     state = climlab.surface_state(T0 = initialT0, num_lat=90, num_lon=180)
     assert state.Ts.ndim == 3
     assert state.Ts.shape == (90, 180, 1)
     assert np.isclose(climlab.global_mean(state.Ts), initialT0, atol=1E-02)
 
+@pytest.mark.fast
 def test_2D_EBM():
     '''Can we step forward a 2D lat/lon EBM?'''
     state = climlab.surface_state(num_lon=4)
@@ -21,6 +22,7 @@ def test_2D_EBM():
     m.step_forward()
     assert m.state.Ts.shape == (90, 4, 1)
 
+@pytest.mark.fast
 def test_2D_insolation():
     state = climlab.surface_state(num_lon=4)
     m = climlab.EBM_annual(state=state)
@@ -28,7 +30,7 @@ def test_2D_insolation():
     #  the mean shouldn't change from 1D to 2D...
     #  there are exactly the same amount of each number in 2D array
     assert np.mean(m.subprocess['insolation'].insolation) == 299.30467670961832
-    from climlab.radiation.insolation import P2Insolation
     sfc = m.domains['Ts']
-    m.add_subprocess('insolation', P2Insolation(domains=sfc, **m.param))
+    m.add_subprocess('insolation',
+        climlab.radiation.P2Insolation(domains=sfc, **m.param))
     assert np.mean(m.subprocess['insolation'].insolation) == 300.34399999999999

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -3,10 +3,7 @@ import numpy as np
 import climlab
 import pytest
 
-# The fixtures are reusable pieces of code to set up the input to the tests.
-# Without fixtures, we would have to do a lot of cutting and pasting
-# These fixtures are based on the notebook
-# Seasonal cycle and heat capacity.ipynb
+
 @pytest.fixture()
 def EBM_seasonal():
     return climlab.EBM_seasonal(water_depth=10.)
@@ -25,12 +22,14 @@ def _check_minmax(array, amin, amax):
     return (np.allclose(array.min(), amin) and
             np.allclose(array.max(), amax))
 
+@pytest.mark.fast
 def test_model_creation(EBM_seasonal):
     """Just make sure we can create a model."""
     assert len(EBM_seasonal.Ts)==90
 
 #  This is not a great test.. but just sees if we reproduce the same
 #  temperature as in the notebook after 1 year of integration
+@pytest.mark.fast
 def test_integrate_years(EBM_seasonal):
     """Check that we can integrate forward the model and get the expected
     surface temperature."""
@@ -39,6 +38,7 @@ def test_integrate_years(EBM_seasonal):
     assert _check_minmax(EBM_seasonal.Ts, -24.21414189, 31.16169215)
 
 #  And do the same thing at high obliquity
+@pytest.mark.fast
 def test_high_obliquity(EBM_highobliquity):
     """Check that we can integrate forward the model and get the expected
     surface temperature."""
@@ -46,12 +46,14 @@ def test_high_obliquity(EBM_highobliquity):
     EBM_highobliquity.integrate_years(1)
     assert _check_minmax(EBM_highobliquity.Ts, -9.28717079958807, 27.37890262018116)
 
+@pytest.mark.fast
 def test_annual_iceline(EBM_iceline):
     '''Check that the annual mean EBM with interactive ice edge gives expected
     result (ice at 70degrees).'''
     EBM_iceline.integrate_years(5.)
     assert np.all(EBM_iceline.icelat == np.array([-70.,  70.]))
 
+@pytest.mark.fast
 def test_decreased_S0(EBM_iceline):
     '''Check that a decrease in solar constant to 1200 W/m2 will give a
     Snowball Earth result in the annual mean EBM.'''
@@ -59,6 +61,7 @@ def test_decreased_S0(EBM_iceline):
     EBM_iceline.integrate_years(5.)
     assert np.all(EBM_iceline.icelat == np.array([-0.,  0.]))
 
+@pytest.mark.fast
 def test_float():
     '''Check that we can step forward the model after setting the state
     variable with an ndarray of integers through 2 different methods'''
@@ -73,16 +76,16 @@ def test_float():
     k.set_state('Ts', Field([10,15,15,10], domain=k.domains['Ts']))
     k.step_forward()
 
+@pytest.mark.fast
 def test_albedo():
     '''Check that we can integrate forward a model after changing the albedo
     subprocess and get the expected icelat'''
     import numpy as np
-    from climlab.surface import albedo
     m = climlab.EBM()
-    m.add_subprocess('albedo', albedo.ConstantAlbedo(state=m.state, **m.param))
+    m.add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
     m.integrate_years(1)
     assert m.icelat == None
-    m.add_subprocess('albedo', albedo.StepFunctionAlbedo(state=m.state, **m.param))
+    m.add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
     m.integrate_years(1)
     assert np.all(m.icelat == np.array([-70.,  70.]))
     assert np.all(m.icelat == m.subprocess.albedo.subprocess.iceline.icelat)

--- a/climlab/tests/test_insolation.py
+++ b/climlab/tests/test_insolation.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import print_function
 import numpy as np
 from climlab import constants as const
 from climlab.solar.insolation import daily_insolation
@@ -55,7 +56,7 @@ def test_long_orbital_parameters():
 #  Tests of automatic orbital cycles with EBM
 def test_orbital_cycles():
     ebm = EBM_seasonal()
-    print ebm
+    print(ebm)
     #  add an albedo feedback
     albedo = StepFunctionAlbedo(state=ebm.state, **ebm.param)
     ebm.add_subprocess('albedo', albedo)

--- a/climlab/tests/test_insolation.py
+++ b/climlab/tests/test_insolation.py
@@ -4,11 +4,13 @@ import numpy as np
 from climlab import constants as const
 from climlab.solar.insolation import daily_insolation
 from climlab.solar.orbital import OrbitalTable, LongOrbitalTable
-from climlab.model.ebm import EBM_seasonal
+from climlab import EBM_seasonal
 from climlab.solar.orbital_cycles import OrbitalCycles
-from climlab.surface.albedo import StepFunctionAlbedo
+from climlab.surface import StepFunctionAlbedo
+import pytest
 
-# mostly copied from Insolation notebook
+
+@pytest.mark.fast
 def test_daily_insolation():
     lat = np.linspace( -90., 90., 500. )
     days = np.linspace(0, const.days_per_year, 365. )
@@ -23,6 +25,7 @@ def test_daily_insolation():
                   np.sum(np.cos(np.deg2rad(lat))) )
     np.testing.assert_almost_equal(Q_area_int, 341.384184481)
 
+@pytest.mark.fast
 def test_orbital_parameters():
     kyears = np.arange( -1000., 1.)
     table = OrbitalTable()
@@ -38,6 +41,7 @@ def test_orbital_parameters():
         assert orb[k].min() > orb_expected[k][0]
         assert orb[k].max() < orb_expected[k][1]
 
+@pytest.mark.slow
 def test_long_orbital_parameters():
     kyears = np.arange( -1000., +500.)
     table = LongOrbitalTable()
@@ -54,9 +58,9 @@ def test_long_orbital_parameters():
         assert orb[k].max() < orb_expected[k][1]
 
 #  Tests of automatic orbital cycles with EBM
+@pytest.mark.slow
 def test_orbital_cycles():
     ebm = EBM_seasonal()
-    print(ebm)
     #  add an albedo feedback
     albedo = StepFunctionAlbedo(state=ebm.state, **ebm.param)
     ebm.add_subprocess('albedo', albedo)

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -6,6 +6,7 @@ from climlab.radiation.rrtm import _climlab_to_rrtm, _rrtm_to_climlab
 
 num_lev = 30
 
+@pytest.mark.fast
 def test_rrtmg_lw_creation():
     state = climlab.column_state(num_lev=num_lev, water_depth=5.)
     rad = climlab.radiation.RRTMG_LW(state=state)
@@ -13,6 +14,7 @@ def test_rrtmg_lw_creation():
     assert np.all(_rrtm_to_climlab(_climlab_to_rrtm(rad.Ts)) == rad.Ts)
     assert np.all(_rrtm_to_climlab(_climlab_to_rrtm(rad.Tatm)) == rad.Tatm)
 
+@pytest.mark.fast
 def test_rrtm_creation():
     # initial state (temperatures)
     state = climlab.column_state(num_lev=num_lev, num_lat=1, water_depth=5.)
@@ -26,6 +28,7 @@ def test_rrtm_creation():
     assert hasattr(rad, 'ASR')
     assert hasattr(rad, 'ASRclr')
 
+@pytest.mark.fast
 def test_swap_component():
     # initial state (temperatures)
     state = climlab.column_state(num_lev=num_lev, num_lat=1, water_depth=5.)
@@ -39,6 +42,7 @@ def test_swap_component():
     rad.step_forward()
     assert hasattr(rad, 'OLR')
 
+@pytest.mark.fast
 def test_multidim():
     state = climlab.column_state(num_lev=40, num_lat=3, water_depth=5.)
     rad = climlab.radiation.RRTMG_LW(state=state)
@@ -49,6 +53,7 @@ def test_multidim():
     rad.step_forward()
     assert rad.OLR.shape == rad.Ts.shape
 
+@pytest.mark.fast
 def test_cloud():
     '''Put a high cloud layer in a radiative model.
     The all-sky ASR should be lower than clear-sky ASR.
@@ -74,6 +79,7 @@ def test_cloud():
         assert(rad.ASR - rad.ASRclr < 0.)
         assert(rad.OLR - rad.OLRclr < 0.)
 
+@pytest.mark.slow
 def test_radiative_forcing():
     '''Run a single-column radiative-convective model with RRTMG radiation
     out to equilibrium. Clone the model, double CO2 and measure the instantaneous
@@ -102,6 +108,7 @@ def test_radiative_forcing():
     rcm2.compute_diagnostics()
     assert (rcm2.ASR - rcm2.OLR) > 1.  # positive radiative forcing
 
+@pytest.mark.slow
 def test_latitude():
     '''
     Run a radiative equilibrum model with RRTMG radiation out to equilibrium

--- a/climlab/utils/walk.py
+++ b/climlab/utils/walk.py
@@ -61,7 +61,7 @@ def walk_processes(top, topname='top', topdown=True, ignoreFlag=False):
         yield topname, proc, level
     if len(proc.subprocess) > 0:  # there are sub-processes
         level += 1
-        for name, subproc in proc.subprocess.iteritems():
+        for name, subproc in proc.subprocess.items():
             for name2, subproc2, level2 in walk_processes(subproc,
                                                           topname=name,
                                                           topdown=subproc.topdown,

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,10 @@
+set CFG=%USERPROFILE%\pydistutils.cfg
+echo [config] > "%CFG%"
+echo compiler=mingw32 >> "%CFG%"
+echo [build] >> "%CFG%"
+echo compiler=mingw32 >> "%CFG%"
+echo [build_ext] >> "%CFG%"
+echo compiler=mingw32 >> "%CFG%"
+
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#  Based on conda-forge recipe for scipy
+export LIBRARY_PATH="${PREFIX}/lib"
+export C_INCLUDE_PATH="${PREFIX}/include"
+export CPLUS_INCLUDE_PATH="${PREFIX}/include"
+
+# Depending on our platform, shared libraries end with either .so or .dylib
+if [[ `uname` == 'Darwin' ]]; then
+    # Also, included a workaround so that `-stdlib=c++` doesn't go to
+    # `gfortran` and cause problems.
+    #
+    # https://github.com/conda-forge/toolchain-feedstock/pull/8
+    export CFLAGS="${CFLAGS} -stdlib=libc++ -lc++"
+    export LDFLAGS="-headerpad_max_install_names -undefined dynamic_lookup -bundle -Wl,-search_paths_first -lc++"
+else
+    unset LDFLAGS
+fi
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 0
+  number: 1
   #skip: True  # [not py2k]
 
 requirements:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev5" %}
+{% set version = "0.6.0.dev6" %}
 
 package:
   name: {{ name|lower }}
@@ -30,6 +30,7 @@ requirements:
     - pytest
     - libgfortran  # [linux or osx]
     - future
+    - numba
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 1
+  number: 3
   #skip: True  # [not py2k]
 
 requirements:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev7" %}
+{% set version = "0.6.0.dev8" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 0
+  number: 2
   #skip: True  # [not py2k]
 
 requirements:
@@ -39,7 +39,7 @@ test:
   imports:
     - climlab
   commands:
-    - py.test -v --pyargs climlab.tests --cov=climlab --cov-config .coveragerc --cov-report term-missing -v
+    - pytest -v -m fast --pyargs climlab.tests --cov=climlab --cov-config .coveragerc --cov-report term-missing -v
 
 about:
   home: https://github.com/brian-rose/climlab

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev8" %}
+{% set version = "0.6.0.dev9" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 2
+  number: 0
   #skip: True  # [not py2k]
 
 requirements:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev9" %}
+{% set version = "0.6.0.dev10" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 3
+  number: 0
   #skip: True  # [not py2k]
 
 requirements:
@@ -29,7 +29,7 @@ requirements:
     - netcdf4
     - libgfortran  # [linux or osx]
     - future
-    - numba
+    - numba  # [py2k]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev1" %}
+{% set version = "0.6.0.dev2" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 1
+  number: 0
   #skip: True  # [not py2k]
 
 requirements:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   build:
     - toolchain
     - mingwpy  # [win]
-    - gcc  # [osx]
+    - gcc  # [osx or linux]
     - python
     - setuptools
     - libgfortran  # [linux]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,21 +9,21 @@ source:
   path: ../
 
 build:
-  number: 0
-  skip: True  # [not py2k]
+  number: 1
+  #skip: True  # [not py2k]
 
 requirements:
   build:
     - toolchain
     - mingwpy  # [win]
     - gcc  # [osx]
-    - python
+    - python 3.6*
     - setuptools
     - libgfortran  # [linux]
     - numpy x.x
 
   run:
-    - python 2.7*
+    - python 3.6*
     - numpy x.x
     - scipy
     - netcdf4

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev3" %}
+{% set version = "0.6.0.dev4" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,18 +1,15 @@
 {% set name = "climlab" %}
-{% set version = "0.5.6" %}
-{% set sha256 = "d445c26e230517722b1d3d36f23fbbd6eb1bf22f0fec72e0cc3130ee0a8d0c74" %}
+{% set version = "0.6.0.dev1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  path: ../
 
 build:
-  number: 2
+  number: 0
   skip: True  # [not py2k]
 
 requirements:
@@ -32,6 +29,7 @@ requirements:
     - netcdf4
     - pytest
     - libgfortran  # [linux or osx]
+    - future
 
 test:
   requires:
@@ -39,7 +37,7 @@ test:
   imports:
     - climlab
   commands:
-    - pytest -v --pyargs climlab.tests.test_rrtm
+    - pytest -v --pyargs climlab.tests
 
 about:
   home: https://github.com/brian-rose/climlab

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev4" %}
+{% set version = "0.6.0.dev5" %}
 
 package:
   name: {{ name|lower }}
@@ -17,13 +17,13 @@ requirements:
     - toolchain
     - mingwpy  # [win]
     - gcc  # [osx]
-    - python 3.6*
+    - python
     - setuptools
     - libgfortran  # [linux]
     - numpy x.x
 
   run:
-    - python 3.6*
+    - python
     - numpy x.x
     - scipy
     - netcdf4

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev2" %}
+{% set version = "0.6.0.dev3" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "climlab" %}
+{% set version = "0.5.6" %}
+{% set sha256 = "d445c26e230517722b1d3d36f23fbbd6eb1bf22f0fec72e0cc3130ee0a8d0c74" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 2
+  skip: True  # [not py2k]
+
+requirements:
+  build:
+    - toolchain
+    - mingwpy  # [win]
+    - gcc  # [osx]
+    - python
+    - setuptools
+    - libgfortran  # [linux]
+    - numpy x.x
+
+  run:
+    - python 2.7*
+    - numpy x.x
+    - scipy
+    - netcdf4
+    - pytest
+    - libgfortran  # [linux or osx]
+
+test:
+  requires:
+    - pytest
+  imports:
+    - climlab
+  commands:
+    - pytest -v --pyargs climlab.tests.test_rrtm
+
+about:
+  home: https://github.com/brian-rose/climlab
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python package for process-oriented climate modeling
+  doc_url: http://climlab.readthedocs.io/
+  dev_url: https://github.com/brian-rose/climlab
+
+extra:
+  recipe-maintainers:
+    - brian-rose

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev6" %}
+{% set version = "0.6.0.dev7" %}
 
 package:
   name: {{ name|lower }}
@@ -27,7 +27,6 @@ requirements:
     - numpy x.x
     - scipy
     - netcdf4
-    - pytest
     - libgfortran  # [linux or osx]
     - future
     - numba
@@ -35,10 +34,12 @@ requirements:
 test:
   requires:
     - pytest
+    - codecov
+    - pytest-cov
   imports:
     - climlab
   commands:
-    - pytest -v --pyargs climlab.tests
+    - py.test -v --pyargs climlab.tests --cov=climlab --cov-config .coveragerc --cov-report term-missing -v
 
 about:
   home: https://github.com/brian-rose/climlab

--- a/conda-recipe/yum_requirements.txt
+++ b/conda-recipe/yum_requirements.txt
@@ -1,0 +1,1 @@
+devtoolset-2-gcc-gfortran

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,6 @@
 name: climlab
 dependencies:
-    - python=2.7
+    - python
     - numpy
     - scipy
     - netCDF4

--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -14,7 +14,7 @@ Stables releases as well as the current development version can be found on gith
 
 Dependencies
 ------------
-`climlab` is written in `Python 2.7 <https://www.python.org/downloads/>`_ and the requires the following `Python` packages to run:
+`climlab` is written in `Python <https://www.python.org/downloads/>`_ and the requires the following `Python` packages to run:
 
   * `Numpy <http://www.numpy.org/>`_
   * `Scipy <https://www.scipy.org/>`_
@@ -25,7 +25,7 @@ Dependencies
   * `Jupyter <http://jupyter.org/>`_ (to run Jupyter notebooks containing tutorials and introduction for climlab)
   * `Matplotlib <http://matplotlib.org/>`_ (plotting libary)
 
-The packages have to be installed on your machine. Either they can be individially downloaded, compiled and installed according to the the instructions on the corresponding websites. 
+The packages have to be installed on your machine. Either they can be individially downloaded, compiled and installed according to the  instructions on the corresponding websites.
 
 Easier to handle however are Python distributions like `Anaconda <https://www.continuum.io/downloads>`_ or `Enthought Canopy <https://www.enthought.com/products/canopy/>`_ which already include many popular Python packages.
 
@@ -39,9 +39,9 @@ An example is given here how to set up a python environment with `Anaconda <http
 		.. code-block:: console
 
 			$ conda create --name climlab_env numpy scipy netcdf4 jupyter matplotlib
-       
+
 	All new packages which will be installed are displayed including their version number. Press ``y`` to proceed.
-	
+
 	After the environment is build, it can be activated with
 
 		.. code-block:: console
@@ -54,8 +54,8 @@ An example is given here how to set up a python environment with `Anaconda <http
 
 			$ source deactivate
 
-	
-To install climlab in the new environment follow the steps below.        
+
+To install climlab in the new environment follow the steps below.
 
 Installation
 ------------
@@ -85,5 +85,3 @@ Development Version
 		.. code-block:: console
 
 			$ python setup.py develop
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev7'
+VERSION = '0.6.0.dev8'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev6'
+VERSION = '0.6.0.dev7'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.5.7.dev0'
+VERSION = '0.6.0.dev0'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev2'
+VERSION = '0.6.0.dev3'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev1'
+VERSION = '0.6.0.dev2'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev9'
+VERSION = '0.6.0.dev10'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev3'
+VERSION = '0.6.0.dev4'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev0'
+VERSION = '0.6.0.dev1'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev8'
+VERSION = '0.6.0.dev9'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev4'
+VERSION = '0.6.0.dev5'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev5'
+VERSION = '0.6.0.dev6'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,


### PR DESCRIPTION
Lots of small changes to the source code, mostly automatically generated with `futurize`, to get Python 2/3 compatibility.

Also include a working `conda build` recipe in the main repo, and use this for automated builds with Travis CI.

Unfortunately a bug in `numba` is causing the `@jit`-compiled version of the ConvectiveAdjustment code to hang forever in Python 3, so use of `@jit` is limited to Python 2.7 for now. A hack in the code checks the Python version at run time. 

I hope to be able to re-write that adjustment code to avoid all those ugly `while` / `break` combinations, which seem to be the source of the problem with numba.