### PR TITLE
Always add up subprocess tendencies

### DIFF
--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.0.dev11'
+__version__ = '0.6.0.dev12'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from climlab.utils import constants

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -191,14 +191,19 @@ class TimeDependentProcess(Process):
             var -= ( (tendencies_implicit[name] + tendencies_explicit[name]) *
                     self.timestep)
         # Finally sum up all the tendencies from all processes
-        self.tendencies = {}
-        for varname in self.state:
-            self.tendencies[varname] = 0. * self.state[varname]
-        for tend_dict in [tendencies_explicit,
-                          tendencies_implicit,
-                          tendencies_adjustment]:
-            for name in tend_dict:
-                self.tendencies[name] += tend_dict[name]
+        #self.tendencies = {}
+        #for varname in self.state:
+        #    self.tendencies[varname] = 0. * self.state[varname]
+        #for tend_dict in [tendencies_explicit,
+        #                  tendencies_implicit,
+        #                  tendencies_adjustment]:
+        #    for name in tend_dict:
+        #        self.tendencies[name] += tend_dict[name]
+        #  Walk the subprocess tree and sum up all tendencies from subprocesses
+        for (name, proc, level) in walk_processes(self,topdown=False):
+            for subname, subproc in proc.subprocess.items():
+                for varname in subproc.tendencies:
+                    proc.tendencies[varname] += subproc.tendencies[varname]
         #  pass diagnostics up the process tree
         #for name, proc in self.subprocess.iteritems():
         #    #self.diagnostics.update(proc.diagnostics)

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -181,34 +181,20 @@ class TimeDependentProcess(Process):
         for name, var in self.state.items():
             var += tendencies_implicit[name] * self.timestep
         # Finally compute all instantaneous adjustments
-        #  and express in terms of discrete timestep
         adjustments = self._compute_type('adjustment')
-        tendencies_adjustment = {}
-        for name in adjustments:
-            tendencies_adjustment[name] = adjustments[name] / self.timestep
+        #  The adjustment is actually ignored here because it is stored
+        #  in proc.tendencies and applied later as if it were an explicit forward step
         #  Now remove the changes from the model state
         for name, var in self.state.items():
             var -= ( (tendencies_implicit[name] + tendencies_explicit[name]) *
                     self.timestep)
-        # Finally sum up all the tendencies from all processes
-        #self.tendencies = {}
-        #for varname in self.state:
-        #    self.tendencies[varname] = 0. * self.state[varname]
-        #for tend_dict in [tendencies_explicit,
-        #                  tendencies_implicit,
-        #                  tendencies_adjustment]:
-        #    for name in tend_dict:
-        #        self.tendencies[name] += tend_dict[name]
         #  Walk the subprocess tree and sum up all tendencies from subprocesses
+        #   By walking with topdown=False we ensure that we don't miss anything
         for (name, proc, level) in walk_processes(self,topdown=False):
             for subname, subproc in proc.subprocess.items():
                 for varname in subproc.tendencies:
                     proc.tendencies[varname] += subproc.tendencies[varname]
-        #  pass diagnostics up the process tree
-        #for name, proc in self.subprocess.iteritems():
-        #    #self.diagnostics.update(proc.diagnostics)
-        #    for diagname, value in proc.diagnostics.iteritems():
-        #        self.__setattr__(diagname, value)
+
 
     def _compute_type(self, proctype):
         """Computes tendencies due to all subprocesses of given type

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.0.dev11" %}
+{% set version = "0.6.0.dev12" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 1
+  number: 2
   #skip: True  # [not py2k]
 
 requirements:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 2
+  number: 3
   #skip: True  # [not py2k]
 
 requirements:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.0.dev11'
+VERSION = '0.6.0.dev12'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,


### PR DESCRIPTION
Some changes to how tendencies are computed and stored.

Now when the `compute()` method is called for any subprocess (which occurs for every timestep), the `tendencies` dictionary of every subprocess is updated with the sum of all its subprocess tendencies.

This doesn't change the model behavior but leaves more useful diagnostic information in all the `tendencies` dictionaries.