### PR TITLE
Fix references and examples

### DIFF
--- a/courseware/Introducing the Column Model.ipynb
+++ b/courseware/Introducing the Column Model.ipynb
@@ -137,7 +137,7 @@
     }
    ],
    "source": [
-    "print mycolumn"
+    "print(mycolumn)"
    ]
   },
   {
@@ -169,7 +169,7 @@
     }
    ],
    "source": [
-    "print mycolumn.state"
+    "print(mycolumn.state)"
    ]
   },
   {
@@ -202,9 +202,9 @@
    ],
    "source": [
     "#  Three ways to get this:\n",
-    "print mycolumn.lev\n",
-    "print mycolumn.Tatm.domain.axes['lev'].points\n",
-    "print mycolumn.domains['Tatm'].axes['lev'].points"
+    "print(mycolumn.lev)\n",
+    "print(mycolumn.Tatm.domain.axes['lev'].points)\n",
+    "print(mycolumn.domains['Tatm'].axes['lev'].points)"
    ]
   },
   {
@@ -320,8 +320,8 @@
    ],
    "source": [
     "mycolumn.compute_diagnostics()\n",
-    "print mycolumn.LW_absorbed_sfc\n",
-    "print mycolumn.LW_absorbed_atm"
+    "print(mycolumn.LW_absorbed_sfc)\n",
+    "print(mycolumn.LW_absorbed_atm)"
    ]
   },
   {
@@ -352,8 +352,8 @@
     }
    ],
    "source": [
-    "print mycolumn.SW_absorbed_sfc\n",
-    "print mycolumn.SW_absorbed_atm"
+    "print(mycolumn.SW_absorbed_sfc)\n",
+    "print(mycolumn.SW_absorbed_atm)"
    ]
   },
   {
@@ -397,8 +397,8 @@
     }
    ],
    "source": [
-    "print mycolumn.LW_absorbed_atm + mycolumn.SW_absorbed_atm\n",
-    "print mycolumn.LW_absorbed_sfc + mycolumn.SW_absorbed_sfc"
+    "print(mycolumn.LW_absorbed_atm + mycolumn.SW_absorbed_atm)\n",
+    "print(mycolumn.LW_absorbed_sfc + mycolumn.SW_absorbed_sfc)"
    ]
   },
   {
@@ -440,7 +440,7 @@
    ],
    "source": [
     "mycolumn.step_forward()\n",
-    "print mycolumn.state"
+    "print(mycolumn.state)"
    ]
   },
   {
@@ -507,7 +507,7 @@
    "source": [
     "for n in range(10):\n",
     "    mycolumn.step_forward()\n",
-    "    print mycolumn.Ts\n"
+    "    print(mycolumn.Ts)\n"
    ]
   },
   {
@@ -546,7 +546,7 @@
    "source": [
     "for n in range(10):\n",
     "    mycolumn.step_forward()\n",
-    "    print mycolumn.Ts"
+    "    print(mycolumn.Ts)"
    ]
   },
   {
@@ -577,7 +577,7 @@
    ],
    "source": [
     "mycolumn.integrate_years(0.3)\n",
-    "print mycolumn.Ts"
+    "print(mycolumn.Ts)"
    ]
   },
   {
@@ -612,7 +612,7 @@
    ],
    "source": [
     "mycolumn.integrate_years(0.3)\n",
-    "print mycolumn.Ts"
+    "print(mycolumn.Ts)"
    ]
   },
   {
@@ -641,8 +641,8 @@
     }
    ],
    "source": [
-    "for key, item in mycolumn.state.iteritems():\n",
-    "    print key, item"
+    "for key, item in mycolumn.state.items():\n",
+    "    print(key, item)"
    ]
   },
   {
@@ -732,7 +732,7 @@
     }
    ],
    "source": [
-    "print mycolumn.OLR"
+    "print(mycolumn.OLR)"
    ]
   },
   {
@@ -758,7 +758,7 @@
     }
    ],
    "source": [
-    "print mycolumn.ASR"
+    "print(mycolumn.ASR)"
    ]
   },
   {
@@ -790,9 +790,9 @@
     "#  Make an exact clone of the model\n",
     "column2 = climlab.process_like(mycolumn)\n",
     "absorptivity = column2.subprocess['LW'].absorptivity\n",
-    "print absorptivity\n",
+    "print(absorptivity)\n",
     "column2.subprocess['LW'].absorptivity *= 1.1 \n",
-    "print column2.subprocess['LW'].absorptivity"
+    "print(column2.subprocess['LW'].absorptivity)"
    ]
   },
   {
@@ -843,7 +843,7 @@
     }
    ],
    "source": [
-    "print column2.OLR"
+    "print(column2.OLR)"
    ]
   },
   {

--- a/courseware/Two_layer_atmosphere.ipynb
+++ b/courseware/Two_layer_atmosphere.ipynb
@@ -175,7 +175,7 @@
    "source": [
     "quarter = sympy.Rational(1,4)\n",
     "out2 = {}\n",
-    "for var4, formula in out1.iteritems():\n",
+    "for var4, formula in out1.items():\n",
     "    var = (var4)**quarter\n",
     "    out2[var] = sympy.simplify(formula**quarter)\n",
     "out2"
@@ -211,7 +211,7 @@
     "#  The special case of equal absorptivities\n",
     "e = sympy.symbols('e')\n",
     "out3 = {}\n",
-    "for var4, formula in out1.iteritems():\n",
+    "for var4, formula in out1.items():\n",
     "    var = (var4)**quarter\n",
     "    simple_formula = sympy.cancel(formula.subs([(e_2, e),(e_1, e)]))\n",
     "    out3[var] = sympy.simplify( simple_formula**quarter )\n",
@@ -288,8 +288,8 @@
     }
    ],
    "source": [
-    "for var, formula in out2.iteritems():\n",
-    "    print formula.subs([(T_e, 255), (e_1, 0.4), (e_2, 0.4)])"
+    "for var, formula in out2.items():\n",
+    "    print(formula.subs([(T_e, 255), (e_1, 0.4), (e_2, 0.4)]))"
    ]
   },
   {
@@ -364,7 +364,7 @@
     }
    ],
    "source": [
-    "print mycolumn"
+    "print(mycolumn)"
    ]
   },
   {
@@ -404,8 +404,8 @@
     }
    ],
    "source": [
-    "print mycolumn.Ts\n",
-    "print mycolumn.Tatm"
+    "print(mycolumn.Ts)\n",
+    "print(mycolumn.Tatm)"
    ]
   },
   {
@@ -425,7 +425,7 @@
    ],
    "source": [
     "(e1, e2)= mycolumn.subprocess['LW'].absorptivity\n",
-    "print e1, e2"
+    "print(e1, e2)"
    ]
   },
   {
@@ -446,7 +446,7 @@
    "source": [
     "ASR = (1-mycolumn.param['albedo_sfc'])*mycolumn.param['Q']\n",
     "Te = (ASR/const.sigma)**0.25\n",
-    "print Te"
+    "print(Te)"
    ]
   },
   {
@@ -472,18 +472,18 @@
     "    (e1, e2)= col.subprocess['LW'].absorptivity\n",
     "    ASR = (1-col.param['albedo_sfc'])*col.param['Q']\n",
     "    Te = (ASR/const.sigma)**0.25\n",
-    "    print 'Surface:'\n",
+    "    print('Surface:')\n",
     "    num = col.Ts\n",
     "    anal = Ts(Te,e1,e2)\n",
-    "    print '  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol\n",
-    "    print 'Level 1'\n",
+    "    print('  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol)\n",
+    "    print('Level 1')\n",
     "    num = col.Tatm[0]\n",
     "    anal = T1(Te,e1,e2)\n",
-    "    print '  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol\n",
-    "    print 'Level 2'\n",
+    "    print('  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol)\n",
+    "    print('Level 2')\n",
     "    num = col.Tatm[1]\n",
     "    anal = T2(Te,e1,e2)\n",
-    "    print '  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol"
+    "    print('  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol)"
    ]
   },
   {
@@ -613,7 +613,7 @@
    "source": [
     "col1 = climlab.GreyRadiationModel(num_lev=2, abs_coeff=1.9E-4)\n",
     "(e1, e2) = col1.subprocess['LW'].absorptivity\n",
-    "print e1, e2\n",
+    "print(e1, e2)\n",
     "col1.integrate_years(10.)\n",
     "test_2level(col1)"
    ]
@@ -953,7 +953,7 @@
    "source": [
     "quarter = sympy.Rational(1,4)\n",
     "out2 = {}\n",
-    "for var4, formula in out1.iteritems():\n",
+    "for var4, formula in out1.items():\n",
     "    var = (var4)**quarter\n",
     "    out2[var] = sympy.simplify(formula**quarter)\n",
     "out2"
@@ -1007,22 +1007,22 @@
     "    (e0, e1, e2)= col.subprocess['LW'].absorptivity\n",
     "    ASR = (1-col.param['albedo_sfc'])*col.param['Q']\n",
     "    Te = (ASR/const.sigma)**0.25\n",
-    "    print 'Surface:'\n",
+    "    print('Surface:')\n",
     "    num = col.Ts\n",
     "    anal = Ts(Te,e0,e1,e2)\n",
-    "    print '  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol\n",
-    "    print 'Level 0'\n",
+    "    print('  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol)\n",
+    "    print('Level 0')\n",
     "    num = col.Tatm[0]\n",
     "    anal = T0(Te,e0,e1,e2)\n",
-    "    print '  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol\n",
-    "    print 'Level 1'\n",
+    "    print('  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol)\n",
+    "    print('Level 1')\n",
     "    num = col.Tatm[1]\n",
     "    anal = T1(Te,e0,e1,e2)\n",
-    "    print '  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol\n",
-    "    print 'Level 2'\n",
+    "    print('  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol)\n",
+    "    print('Level 2')\n",
     "    num = col.Tatm[2]\n",
     "    anal = T2(Te,e0,e1,e2)\n",
-    "    print '  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol"
+    "    print('  Numerical: %.2f   Analytical: %.2f    Same:' %(num, anal) , abs(num - anal)<tol)"
    ]
   },
   {
@@ -1130,7 +1130,7 @@
    "source": [
     "# The 3-layer solution reduces to two layer solution if we set e_2 = 0\n",
     "out3 = {}\n",
-    "for var, formula in out2.iteritems():\n",
+    "for var, formula in out2.items():\n",
     "    if var is not T_2:\n",
     "        out3[var] = sympy.simplify(formula.subs(epsilon_2,0))\n",
     "out3"

--- a/paper.bib
+++ b/paper.bib
@@ -1,6 +1,6 @@
 
 @article{Jeevanjee:2017a,
-	Author = {Nadir Jeevanjee and Pedram Hassanzadeh and Spencer A. Hill and Aditi Sheshadri},
+	Author = {Nadir Jeevanjee and Pedram Hassanzadeh and Spencer Hill and Aditi Sheshadri},
 	Doi = {10.1002/2017MS001038},
 	Journal = {J. Adv. Model. Earth Syst.},
 	Pages = {1760--1771},
@@ -11,6 +11,7 @@
 
 @article{Held:2005fk,
 	Author = {Isaac M. Held},
+    Doi = {10.1175/BAMS-86-11-1609},
 	Journal = {Bull. Amer. Meteor. Soc.},
 	Number = {11},
 	Pages = {1609--1614},
@@ -42,7 +43,7 @@
 @article{Clough:2005a,
 	Author = {Clough, S.A. and M.W. Shepard and E.J. Mlawer and J.S. Delamere and M.J. Iacono and K. Cady-Pereira and S. Boukabara and P.D. Brown},
 	Doi = {10.1016/j.jqsrt.2004.05.058},
-	Journal = {J. Quant. Spectrosocopy Radiative Transfer},
+	Journal = {J. Quant. Spectroscopy Radiative Transfer},
 	Pages = {233--244},
 	Title = {Atmospheric radiative transfer modeling: a summary of the {AER} codes},
 	Volume = {91},
@@ -51,15 +52,17 @@
 
 @article{Emanuel:1991a,
 	Author = {Kerry A. Emanuel},
+    Doi = {10.1175/1520-0469(1991)048<2313:ASFRCC>2.0.CO;2},
 	Journal = {J. Atmos. Sci.},
 	Pages = {2313--2314},
 	Title = {A Scheme for Representing Cumulus Convection in Large-Scale Models},
 	Volume = {48},
 	Year = {1991},
-}
+    }
 
 @article{Emanuel:1999a,
 	Author = {Kerry A. Emanuel and Marina {\v Z}ivkovi{\'c}-Rothman},
+    Doi = {10.1175/1520-0469(1999)056<1766:DAEOAC>2.0.CO;2},
 	Journal = {J. Atmos. Sci.},
 	Pages = {1766--1782},
 	Title = {Development and Evaluation of a Convection Scheme for Use in Climate Models},


### PR DESCRIPTION
In connection with the review in https://github.com/openjournals/joss-reviews/issues/659, this PR fixes the references for the JOSS paper by adding DOIs. Additonally, two examples have been ported from Python 2.7 to Python 3, since the [docs](http://climlab.readthedocs.io/en/latest/installation.html#required) claim, that climlab is made for this version.