### PR TITLE
New and improved EBMs including moist option!

### DIFF
--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.6.dev1'
+__version__ = '0.6.6.dev2'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.6.dev0'
+__version__ = '0.6.6.dev1'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.6.dev3'
+__version__ = '0.6.6.dev4'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.6.dev4'
+__version__ = '0.6.6.dev5'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.6.6.dev2'
+__version__ = '0.6.6.dev3'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants

--- a/climlab/dynamics/__init__.py
+++ b/climlab/dynamics/__init__.py
@@ -1,4 +1,4 @@
 '''Modules for horizontal transport processes in climlab.'''
 from __future__ import absolute_import
 from .budyko_transport import BudykoTransport
-from .diffusion import Diffusion, MeridionalDiffusion
+from .diffusion import Diffusion, MeridionalDiffusion, MeridionalHeatDiffusion

--- a/climlab/dynamics/__init__.py
+++ b/climlab/dynamics/__init__.py
@@ -1,4 +1,4 @@
 '''Modules for horizontal transport processes in climlab.'''
 from __future__ import absolute_import
 from .budyko_transport import BudykoTransport
-from .diffusion import Diffusion, MeridionalDiffusion, MeridionalHeatDiffusion
+from .diffusion import Diffusion, MeridionalDiffusion, MeridionalHeatDiffusion, MeridionalMoistDiffusion

--- a/climlab/dynamics/diffusion.py
+++ b/climlab/dynamics/diffusion.py
@@ -141,12 +141,15 @@ class Diffusion(ImplicitProcess):
             else:
                 newvar = np.linalg.solve(self.diffTriDiag, value)
             newstate[varname] = newvar
+        return newstate
+
+    def _update_diagnostics(self, newstate):
+        for varname, value in newstate.items():
             # Diagnostic calculations of flux and convergence
             #  These assume 1D state variables...
             K = self.K_dimensionless * self.delta**2/self.timestep  # length**2 / time
-            self.diffusive_flux[1:-1] = -K[1:-1] * np.diff(np.squeeze(newvar))/self.delta  # length / time
+            self.diffusive_flux[1:-1] = -K[1:-1] * np.diff(np.squeeze(value))/self.delta  # length / time
             self.diffusive_flux_convergence[:] = -np.diff(self.diffusive_flux)/self.delta # 1/time
-        return newstate
 
 
 def _solve_implicit_banded(current, banded_matrix):

--- a/climlab/dynamics/diffusion.py
+++ b/climlab/dynamics/diffusion.py
@@ -305,8 +305,8 @@ class MeridionalHeatDiffusion(MeridionalDiffusion):
 
 class MeridionalMoistDiffusion(MeridionalHeatDiffusion):
     def __init__(self, D=0.24, relative_humidity=0.8, **kwargs):
-        super(MoistDiffusion, self).__init__(D=D, **kwargs)
-        self.add_input('relative_humidity', relative_humidity)
+        self.relative_humidity = relative_humidity
+        super(MeridionalMoistDiffusion, self).__init__(D=D, **kwargs)
         self._update_diffusivity()
 
     def _update_diffusivity(self):
@@ -317,9 +317,9 @@ class MeridionalMoistDiffusion(MeridionalHeatDiffusion):
         self.K = self.D / heat_capacity * const.a**2 * (1+f)
 
     def _implicit_solver(self):
-        self.update_diffusivity()
+        self._update_diffusivity()
         #  and then do all the same stuff the parent class would do...
-        return super(MoistDiffusion, self)._implicit_solver()
+        return super(MeridionalMoistDiffusion, self)._implicit_solver()
 
 
 def _make_diffusion_matrix(K, weight1=None, weight2=None):

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -186,8 +186,8 @@ class EBM(TimeDependentProcess):
                                      insolation=ins.insolation,
                                      albedo=alb.albedo,
                                      **self.param)
-        sw.add_subprocess('insolation', ins)
-        sw.add_subprocess('albedo', alb)
+        self.add_subprocess('insolation', ins)
+        self.add_subprocess('albedo', alb)
         self.add_subprocess('SW', sw)
 
         # diffusivity in units of 1/s

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -143,6 +143,7 @@ class EBM(TimeDependentProcess):
     def __init__(self,
                  num_lat=90,
                  S0=const.S0,
+                 s2=-0.48,
                  A=210.,
                  B=2.,
                  D=0.555,  # in W / m^2 / degC, same as B
@@ -165,6 +166,7 @@ class EBM(TimeDependentProcess):
         super(EBM, self).__init__(timestep=timestep, **kwargs)
         sfc = self.Ts.domain
         self.param['S0'] = S0
+        self.param['s2'] = s2
         self.param['A'] = A
         self.param['B'] = B
         self.param['D'] = D

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -174,20 +174,16 @@ class EBM(TimeDependentProcess):
         self.param['a2'] = a2
         self.param['ai'] = ai
         # create sub-models
-        self.add_subprocess('LW', AplusBT(state=self.state, **self.param))
-        #self.add_subprocess('insolation',
-        #                    P2Insolation(domains=sfc, **self.param))
-        #self.add_subprocess('albedo',
-        #                    albedo.StepFunctionAlbedo(state=self.state,
-        #                                              **self.param))
+        lw = AplusBT(state=self.state, **self.param)
         ins = P2Insolation(domains=sfc, **self.param)
         alb = albedo.StepFunctionAlbedo(state=self.state, **self.param)
         sw = SimpleAbsorbedShortwave(state=self.state,
                                      insolation=ins.insolation,
                                      albedo=alb.albedo,
                                      **self.param)
-        self.add_subprocess('insolation', ins)
-        self.add_subprocess('albedo', alb)
+        self.add_subprocess('LW', lw)
+        sw.add_subprocess('insolation', ins)
+        sw.add_subprocess('albedo', alb)
         self.add_subprocess('SW', sw)
 
         # diffusivity in units of 1/s
@@ -197,11 +193,7 @@ class EBM(TimeDependentProcess):
                                                         use_banded_solver=True,
                                                              **self.param))
         self.topdown = False  # call subprocess compute methods first
-        #self.add_diagnostic('ASR', 0.*self.Ts)
         self.add_diagnostic('net_radiation', 0.*self.Ts)
-        #self.add_diagnostic('albedo', 0.*self.Ts)
-        #self.add_diagnostic('icelat', None)
-        #self.add_diagnostic('ice_area', None)
 
     @property
     def S0(self):

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -182,8 +182,8 @@ class EBM(TimeDependentProcess):
                                      albedo=alb.albedo,
                                      **self.param)
         self.add_subprocess('LW', lw)
-        sw.add_subprocess('insolation', ins)
-        sw.add_subprocess('albedo', alb)
+        self.add_subprocess('insolation', ins)
+        self.add_subprocess('albedo', alb)
         self.add_subprocess('SW', sw)
 
         # diffusivity in units of 1/s
@@ -197,11 +197,11 @@ class EBM(TimeDependentProcess):
 
     @property
     def S0(self):
-        return self.subprocess['SW'].subprocess['insolation'].S0
+        return self.subprocess['insolation'].S0
     @S0.setter
     def S0(self, value):
         self.param['S0'] = value
-        self.subprocess['SW'].subprocess['insolation'].S0 = value
+        self.subprocess['insolation'].S0 = value
 
     def _compute(self):
         self.net_radiation = self.subprocess['SW'].ASR - self.subprocess['LW'].OLR
@@ -396,8 +396,8 @@ class EBM_seasonal(EBM):
                                      insolation=ins.insolation,
                                      albedo=alb.albedo,
                                      **self.param)
-        sw.add_subprocess('insolation', ins)
-        sw.add_subprocess('albedo', alb)
+        self.add_subprocess('insolation', ins)
+        self.add_subprocess('albedo', alb)
         self.add_subprocess('SW', sw)
 
 
@@ -452,7 +452,7 @@ class EBM_annual(EBM_seasonal):
         super(EBM_annual, self).__init__(**kwargs)
         sfc = self.domains['Ts']
         ins = AnnualMeanInsolation(domains=sfc, **self.param)
-        self.subprocess['SW'].add_subprocess('insolation', ins)
+        self.add_subprocess('insolation', ins)
         self.subprocess['SW'].insolation = ins.insolation
 
 # an EBM that computes degree-days has an additional state variable.

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -7,7 +7,7 @@ from climlab.utils import legendre
 from climlab.domain import domain
 from climlab.radiation import AplusBT, P2Insolation, AnnualMeanInsolation, DailyInsolation, SimpleAbsorbedShortwave
 from climlab.surface import albedo
-from climlab.dynamics import MeridionalDiffusion
+from climlab.dynamics import MeridionalHeatDiffusion
 from climlab.domain.initial import surface_state
 from scipy import integrate
 
@@ -17,53 +17,6 @@ from scipy import integrate
 
 #  For example, the basic EBM should be created with something like
 #  ebm = climlab.couple([asr,olr,diff])
-
-
-class MeridionalHeatDiffusion(MeridionalDiffusion):
-    '''A 1D diffusion solver for Energy Balance Models.
-
-    Solves the meridional heat diffusion equation
-
-    $$ C \frac{\partial T}{\partial t} = -\frac{1}{\cos\phi} \frac{\partial}{\partial \phi} \left[ -D \cos\phi \frac{\partial T}{\partial \phi} \right]$$
-
-    on an evenly-spaced latitude grid, with a state variable $T$, a heat capacity $C$ and diffusivity $D$.
-
-    Assuming $T$ is a temperature in $K$ or $^\circ$C, then the units are:
-
-    - $D$ in W m$^{-2}$ K$^{-1}$
-    - $C$ in J m$^{-2}$ K$^{-1}$
-
-    If the state variable has other units, then $D$ and $C$ should be expressed
-    per state variabe unit.
-
-    $D$ is provided as input, and can be either scalar
-    or vector defined at latitude boundaries (length).
-
-    $C$ is normally handled automatically for temperature state variables in CLIMLAB.
-    '''
-    def __init__(self,
-                 D=0.555,  # in W / m^2 / degC
-                 use_banded_solver=True,
-                 **kwargs):
-        self.D = D
-        state = kwargs['state']
-        for varname, value in state.items():
-            heat_capacity = value.domain.heat_capacity
-        # diffusivity in units of 1/s
-        K = self.D / heat_capacity
-        super(MeridionalHeatDiffusion, self).__init__(K=K,
-                        use_banded_solver=use_banded_solver, **kwargs)
-        self.add_diagnostic('heat_transport', np.zeros_like(self.lat_bounds))
-        self.add_diagnostic('heat_transport_convergence', np.zeros_like(self.lat))
-
-    def _update_diagnostics(self, newstate):
-        super(MeridionalHeatDiffusion, self)._update_diagnostics(newstate)
-        for varname, value in self.state.items():
-            heat_capacity = value.domain.heat_capacity
-        self.heat_transport[:] = (self.diffusive_flux * heat_capacity *
-                        2 * np.pi * const.a * self._weight1 * 1E-15) # in PW
-        self.heat_transport_convergence[:] = (self.diffusive_flux_convergence *
-                        heat_capacity)  # in W/m**2
 
 
 class EBM(TimeDependentProcess):
@@ -328,7 +281,7 @@ class EBM(TimeDependentProcess):
         :rtype: array of size ``np.size(self.lat_bounds)``
 
         THIS IS DEPRECATED AND WILL BE REMOVED IN THE FUTURE. Use the diagnostic
-        ``heat_transport`` instead, which implements the same calculation. 
+        ``heat_transport`` instead, which implements the same calculation.
         """
         phi = np.deg2rad(self.lat)
         phi_stag = np.deg2rad(self.lat_bounds)

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -39,7 +39,7 @@ class MeridionalHeatDiffusion(MeridionalDiffusion):
     $D$ is provided as input, and can be either scalar
     or vector defined at latitude boundaries (length).
 
-    $C$ is normally handled automatically for temperature state variables in CLIMLAB. 
+    $C$ is normally handled automatically for temperature state variables in CLIMLAB.
     '''
     def __init__(self,
                  D=0.555,  # in W / m^2 / degC
@@ -90,6 +90,9 @@ class EBM(TimeDependentProcess):
                                 :class:`~climlab.domain.domain.zonal_mean_surface`
                                                                             \n
                                 - default value: ``90``
+    :param int num_lon:         number of equally spaced points in longitude
+                                                                            \n
+                                - default value: ``None``
     :param float S0:            solar constant                              \n
                                 - unit: :math:`\\frac{\\textrm{W}}{\\textrm{m}^2}`   \n
                                 - default value: ``1365.2``
@@ -190,6 +193,7 @@ class EBM(TimeDependentProcess):
     """
     def __init__(self,
                  num_lat=90,
+                 num_lon=None,
                  S0=const.S0,
                  s2=-0.48,
                  A=210.,
@@ -207,8 +211,8 @@ class EBM(TimeDependentProcess):
         # Check to see if an initial state is already provided
         #  If not, make one
         if 'state' not in kwargs:
-            state = surface_state(num_lat=num_lat, water_depth=water_depth,
-                                  T0=T0, T2=T2)
+            state = surface_state(num_lat=num_lat, num_lon=num_lon,
+                                  water_depth=water_depth, T0=T0, T2=T2)
             sfc = state.Ts.domain
             kwargs.update({'state': state, 'domains':{'sfc':sfc}})
         super(EBM, self).__init__(timestep=timestep, **kwargs)

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -32,22 +32,15 @@ class MeridionalHeatDiffusion(MeridionalDiffusion):
         K = self.D / heat_capacity
         super(MeridionalHeatDiffusion, self).__init__(K=K,
                         use_banded_solver=use_banded_solver, **kwargs)
-        self._diag_vars.append('heat_transport2')
-        self._diag_vars.append('heat_transport_convergence2')
+        self.add_diagnostic('heat_transport2', np.zeros_like(self.lat_bounds))
+        self.add_diagnostic('heat_transport_convergence2', np.zeros_like(self.lat))
 
-    @property
-    def heat_transport2(self):
-        '''Heat transport in PW'''
-        return self.diffusive_flux * 1E15
-
-    @property
-    def heat_transport_convergence2(self):
-        '''Heat transport convergence in W/m**2'''
+    def _update_diagnostics(self, newstate):
+        super(MeridionalHeatDiffusion, self)._update_diagnostics(newstate)
         for varname, value in self.state.items():
             heat_capacity = value.domain.heat_capacity
-        return self.diffusive_flux_convergence * heat_capacity
-
-
+        self.heat_transport2[:] = self.diffusive_flux * 1E15  # in PW... fix this
+        self.heat_transport_convergence2[:] = self.diffusive_flux_convergence * heat_capacity  # in W/m**2
 
 
 class EBM(TimeDependentProcess):

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -39,8 +39,10 @@ class MeridionalHeatDiffusion(MeridionalDiffusion):
         super(MeridionalHeatDiffusion, self)._update_diagnostics(newstate)
         for varname, value in self.state.items():
             heat_capacity = value.domain.heat_capacity
-        self.heat_transport2[:] = self.diffusive_flux * 1E15  # in PW... fix this
-        self.heat_transport_convergence2[:] = self.diffusive_flux_convergence * heat_capacity  # in W/m**2
+        self.heat_transport2[:] = (self.diffusive_flux * heat_capacity *
+                        2 * np.pi * const.a * self._weight1 * 1E-15) # in PW
+        self.heat_transport_convergence2[:] = (self.diffusive_flux_convergence *
+                        heat_capacity)  # in W/m**2
 
 
 class EBM(TimeDependentProcess):

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -20,6 +20,27 @@ from scipy import integrate
 
 
 class MeridionalHeatDiffusion(MeridionalDiffusion):
+    '''A 1D diffusion solver for Energy Balance Models.
+
+    Solves the meridional heat diffusion equation
+
+    $$ C \frac{\partial T}{\partial t} = -\frac{1}{\cos\phi} \frac{\partial}{\partial \phi} \left[ -D \cos\phi \frac{\partial T}{\partial \phi} \right]$$
+
+    on an evenly-spaced latitude grid, with a state variable $T$, a heat capacity $C$ and diffusivity $D$.
+
+    Assuming $T$ is a temperature in $K$ or $^\circ$C, then the units are:
+
+    - $D$ in W m$^{-2}$ K$^{-1}$
+    - $C$ in J m$^{-2}$ K$^{-1}$
+
+    If the state variable has other units, then $D$ and $C$ should be expressed
+    per state variabe unit.
+
+    $D$ is provided as input, and can be either scalar
+    or vector defined at latitude boundaries (length).
+
+    $C$ is normally handled automatically for temperature state variables in CLIMLAB. 
+    '''
     def __init__(self,
                  D=0.555,  # in W / m^2 / degC
                  use_banded_solver=True,

--- a/climlab/process/implicit.py
+++ b/climlab/process/implicit.py
@@ -49,7 +49,7 @@ class ImplicitProcess(TimeDependentProcess):
         tendencies = {}
         for name, var in self.state.items():
             adjustment[name] = newstate[name] - var
-            tendencies[name] = adjustment[name] / self.param['timestep']
+            tendencies[name] = adjustment[name] / self.timestep
         # express the adjustment (already accounting for the finite time step)
         #  as a tendency per unit time, so that it can be applied along with explicit
         self.adjustment = adjustment

--- a/climlab/process/implicit.py
+++ b/climlab/process/implicit.py
@@ -53,4 +53,11 @@ class ImplicitProcess(TimeDependentProcess):
         # express the adjustment (already accounting for the finite time step)
         #  as a tendency per unit time, so that it can be applied along with explicit
         self.adjustment = adjustment
+        self._update_diagnostics(newstate)
         return tendencies
+
+    def _update_diagnostics(self, newstate):
+        '''This method is called each timestep after the new state is computed
+        with the implicit solver. Daughter classes can implement this method to
+        compute any diagnostic quantities using the new state.'''
+        pass

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -591,8 +591,9 @@ class Process(object):
         diag_dict = {}
         for key in self._diag_vars:
             try:
-                #diag_dict[key] = getattr(self,key)
-                diag_dict[key] = self.__dict__[key]
+                diag_dict[key] = getattr(self,key)
+                #  using self.__dict__ doesn't count diagnostics defined as properties
+                #diag_dict[key] = self.__dict__[key]
             except:
                 pass
         return diag_dict

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -274,8 +274,9 @@ class Process(object):
             # Add subprocess diagnostics to parent
             #  (if there are no name conflicts)
             for diagname, value in proc.diagnostics.items():
-                if not (diagname in self.diagnostics or hasattr(self, diagname)):
-                    self.add_diagnostic(diagname, value)
+                #if not (diagname in self.diagnostics or hasattr(self, diagname)):
+                #    self.add_diagnostic(diagname, value)
+                self.add_diagnostic(diagname, value)
         else:
             raise ValueError('subprocess must be Process object')
 

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -591,9 +591,9 @@ class Process(object):
         diag_dict = {}
         for key in self._diag_vars:
             try:
-                diag_dict[key] = getattr(self,key)
+                #diag_dict[key] = getattr(self,key)
                 #  using self.__dict__ doesn't count diagnostics defined as properties
-                #diag_dict[key] = self.__dict__[key]
+                diag_dict[key] = self.__dict__[key]
             except:
                 pass
         return diag_dict

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -343,11 +343,7 @@ class TimeDependentProcess(Process):
 
         """
         for n in range(num_iter):
-            self.compute()
-        #  Pass diagnostics up the process tree
-        for name, proc, level in walk.walk_processes(self, ignoreFlag=True):
-            for diagname, value in proc.diagnostics.items():
-                self.__setattr__(diagname, value)
+            ignored = self.compute()
 
     def _update_time(self):
         """Increments the timestep counter by one.

--- a/climlab/radiation/absorbed_shorwave.py
+++ b/climlab/radiation/absorbed_shorwave.py
@@ -25,6 +25,7 @@ class SimpleAbsorbedShortwave(EnergyBudget):
         self.add_input('albedo', albedo)
         self.add_input('insolation', insolation)
         self.add_diagnostic('ASR', 0.*self.Ts)
+        self.topdown = False  # call subprocess compute methods first
 
     def _compute_heating_rates(self):
         self.ASR = (1-self.albedo) * self.insolation

--- a/climlab/radiation/absorbed_shorwave.py
+++ b/climlab/radiation/absorbed_shorwave.py
@@ -5,6 +5,7 @@ from climlab import constants as const
 
 class SimpleAbsorbedShortwave(EnergyBudget):
     '''A class for the shortwave radiation process in a one-layer EBM.
+    The basic assumption is that all the shortwave absorption occurs at the surface.
 
     Computes the diagnostic `ASR` (absorbed shortwave radiation)
     from the formula `self.ASR = (1-self.albedo) * self.insolation`
@@ -15,8 +16,7 @@ class SimpleAbsorbedShortwave(EnergyBudget):
 
     User can supply constants, or link to diagnostics of specific insolation
     and albedo processes.
-
-    added as beta feature in climlab 0.6.4 '''
+    '''
     def __init__(self,
                  insolation=const.S0/4,
                  albedo=0.3,

--- a/climlab/surface/albedo.py
+++ b/climlab/surface/albedo.py
@@ -226,7 +226,7 @@ class Iceline(DiagnosticProcess):
 
     """
     def __init__(self, Tf=-10., **kwargs):
-        super(DiagnosticProcess, self).__init__(**kwargs)
+        super(Iceline, self).__init__(**kwargs)
         self.param['Tf'] = Tf
         self.add_diagnostic('icelat')
         self.add_diagnostic('ice_area')
@@ -353,7 +353,7 @@ class StepFunctionAlbedo(DiagnosticProcess):
 
     """
     def __init__(self, Tf=-10., a0=0.3, a2=0.078, ai=0.62, **kwargs):
-        super(DiagnosticProcess, self).__init__(**kwargs)
+        super(StepFunctionAlbedo, self).__init__(**kwargs)
         self.param['Tf'] = Tf
         self.param['a0'] = a0
         self.param['a2'] = a2

--- a/climlab/surface/albedo.py
+++ b/climlab/surface/albedo.py
@@ -362,6 +362,10 @@ class StepFunctionAlbedo(DiagnosticProcess):
         self.add_subprocess('iceline', Iceline(Tf=Tf, state=self.state, timestep=self.timestep))
         self.add_subprocess('warm_albedo', P2Albedo(a0=a0, a2=a2, domains=sfc, timestep=self.timestep))
         self.add_subprocess('cold_albedo', ConstantAlbedo(albedo=ai, domains=sfc, timestep=self.timestep))
+        # remove `albedo` from the diagnostics list for the two subprocesses
+        #  because they cause conflicts when passed up the subprocess tree
+        for name in ['warm_albedo', 'cold_albedo']:
+            self.subprocess[name]._diag_vars.remove('albedo')
         self.topdown = False  # call subprocess compute methods first
         self.add_diagnostic('albedo', self._get_current_albedo())
 
@@ -375,5 +379,5 @@ class StepFunctionAlbedo(DiagnosticProcess):
         return albedo
 
     def _compute(self):
-        self.albedo = self._get_current_albedo()
+        self.albedo[:] = self._get_current_albedo()
         return {}

--- a/climlab/surface/albedo.py
+++ b/climlab/surface/albedo.py
@@ -360,12 +360,14 @@ class StepFunctionAlbedo(DiagnosticProcess):
         self.param['ai'] = ai
         sfc = self.domains['Ts']
         self.add_subprocess('iceline', Iceline(Tf=Tf, state=self.state, timestep=self.timestep))
-        self.add_subprocess('warm_albedo', P2Albedo(a0=a0, a2=a2, domains=sfc, timestep=self.timestep))
-        self.add_subprocess('cold_albedo', ConstantAlbedo(albedo=ai, domains=sfc, timestep=self.timestep))
+        warm = P2Albedo(a0=a0, a2=a2, domains=sfc, timestep=self.timestep)
+        cold = ConstantAlbedo(albedo=ai, domains=sfc, timestep=self.timestep)
         # remove `albedo` from the diagnostics list for the two subprocesses
         #  because they cause conflicts when passed up the subprocess tree
-        for name in ['warm_albedo', 'cold_albedo']:
-            self.subprocess[name]._diag_vars.remove('albedo')
+        for proc in [warm, cold]:
+            proc._diag_vars.remove('albedo')
+        self.add_subprocess('warm_albedo', warm)
+        self.add_subprocess('cold_albedo', cold)
         self.topdown = False  # call subprocess compute methods first
         self.add_diagnostic('albedo', self._get_current_albedo())
 

--- a/climlab/tests/test_cam3rad.py
+++ b/climlab/tests/test_cam3rad.py
@@ -23,6 +23,8 @@ def rcm():
     rcm = climlab.couple([h2o,convadj,rad], name='RCM')
     return rcm
 
+
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_rce(rcm):
     '''Test a single-column radiative-convective model with CAM3 radiation and
@@ -35,7 +37,7 @@ def test_rce(rcm):
     # Test the xarray interface
     to_xarray(rcm)
 
-
+@pytest.mark.compiled
 @pytest.mark.slow
 def test_re_radiative_forcing():
     state = climlab.column_state(num_lev=num_lev)
@@ -47,6 +49,7 @@ def test_re_radiative_forcing():
     rad2.compute_diagnostics()
     assert (rad2.ASR - rad2.OLR) > 1.  # positive radiative forcing
 
+@pytest.mark.compiled
 @pytest.mark.slow
 def test_rce_radiative_forcing(rcm):
     '''Run a single-column radiative-convective model with CAM3 radiation
@@ -59,6 +62,7 @@ def test_rce_radiative_forcing(rcm):
     rcm2.compute_diagnostics()
     assert (rcm2.ASR - rcm2.OLR) > 1.  # positive radiative forcing
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_cam3_multidim():
     state = climlab.column_state(num_lev=40, num_lat=3, water_depth=5.)

--- a/climlab/tests/test_domain2D.py
+++ b/climlab/tests/test_domain2D.py
@@ -17,8 +17,9 @@ def test_state():
 @pytest.mark.fast
 def test_2D_EBM():
     '''Can we step forward a 2D lat/lon EBM?'''
-    state = climlab.surface_state(num_lon=4)
-    m = climlab.EBM_annual(state=state)
+    #state = climlab.surface_state(num_lon=4)
+    #m = climlab.EBM_annual(state=state)
+    m = climlab.EBM_annual(num_lon=4)
     m.step_forward()
     assert m.state.Ts.shape == (90, 4, 1)
     # Test the xarray interface
@@ -26,8 +27,9 @@ def test_2D_EBM():
 
 @pytest.mark.fast
 def test_2D_insolation():
-    state = climlab.surface_state(num_lon=4)
-    m = climlab.EBM_annual(state=state)
+    #state = climlab.surface_state(num_lon=4)
+    #m = climlab.EBM_annual(state=state)
+    m = climlab.EBM_annual(num_lon=4)
     #  the answers are the mean of 1D insolation arrays
     #  the mean shouldn't change from 1D to 2D...
     #  there are exactly the same amount of each number in 2D array

--- a/climlab/tests/test_domain2D.py
+++ b/climlab/tests/test_domain2D.py
@@ -31,8 +31,8 @@ def test_2D_insolation():
     #  the answers are the mean of 1D insolation arrays
     #  the mean shouldn't change from 1D to 2D...
     #  there are exactly the same amount of each number in 2D array
-    assert np.mean(m.subprocess['insolation'].insolation) == 299.30467670961832
+    assert np.mean(m.subprocess['SW'].subprocess['insolation'].insolation) == 299.30467670961832
     sfc = m.domains['Ts']
-    m.add_subprocess('insolation',
+    m.subprocess['SW'].add_subprocess('insolation',
         climlab.radiation.P2Insolation(domains=sfc, **m.param))
-    assert np.mean(m.subprocess['insolation'].insolation) == 300.34399999999999
+    assert np.mean(m.subprocess['SW'].subprocess['insolation'].insolation) == 300.34399999999999

--- a/climlab/tests/test_domain2D.py
+++ b/climlab/tests/test_domain2D.py
@@ -31,8 +31,8 @@ def test_2D_insolation():
     #  the answers are the mean of 1D insolation arrays
     #  the mean shouldn't change from 1D to 2D...
     #  there are exactly the same amount of each number in 2D array
-    assert np.mean(m.subprocess['SW'].subprocess['insolation'].insolation) == 299.30467670961832
+    assert np.mean(m.subprocess['insolation'].insolation) == 299.30467670961832
     sfc = m.domains['Ts']
-    m.subprocess['SW'].add_subprocess('insolation',
+    m.add_subprocess('insolation',
         climlab.radiation.P2Insolation(domains=sfc, **m.param))
-    assert np.mean(m.subprocess['SW'].subprocess['insolation'].insolation) == 300.34399999999999
+    assert np.mean(m.subprocess['insolation'].insolation) == 300.34399999999999

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -121,3 +121,14 @@ def test_analytical():
     x = np.sin(np.deg2rad(m.lat))
     Tanalytical = ((1-param['a0'])*param['S0']/4*(1+param['s2']*P2(x)/(1+6*delta))-param['A'])/param['B']
     assert Tnumerical == pytest.approx(Tanalytical, abs=2E-2)
+
+@pytest.mark.fast
+def test_moist_EBM_creation():
+    '''See if we can swap a moist diffusion module for the dry diffusion
+    and just step forward once.'''
+    m = climlab.EBM()
+    m.remove_subprocess('diffusion')
+    diff = climlab.dynamics.MeridionalMoistDiffusion(state=m.state, timestep=m.timestep)
+    m.add_subprocess('diffusion', diff)
+    m.step_forward()
+    assert hasattr(m, 'heat_transport')

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -86,13 +86,14 @@ def test_albedo():
     subprocess and get the expected icelat'''
     import numpy as np
     m = climlab.EBM()
-    m.subprocess['SW'].add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
+    m.add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
+    m.subprocess['SW'].albedo = m.subprocess['albedo'].albedo
     m.integrate_years(1)
-    assert m.icelat == None
-    m.subprocess['SW'].add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
+    m.add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
+    m.subprocess['SW'].albedo = m.subprocess['albedo'].albedo
     m.integrate_years(1)
     assert np.all(m.icelat == np.array([-70.,  70.]))
-    assert np.all(m.icelat == m.subprocess.albedo.subprocess.iceline.icelat)
+    assert np.all(m.icelat == m.subprocess['albedo'].subprocess['iceline'].icelat)
     #  What is the expected behavior if we swap out a subprocess for another
     #  and they have different diagnostics???
     #m.add_subprocess('albedo', albedo.ConstantAlbedo(state=m.state, **m.param))

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -86,14 +86,14 @@ def test_albedo():
     subprocess and get the expected icelat'''
     import numpy as np
     m = climlab.EBM()
-    m.subprocess['SW'].add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
-    m.subprocess['SW'].albedo = m.subprocess['SW'].subprocess['albedo'].albedo
+    m.add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
+    m.subprocess['SW'].albedo = m.subprocess['albedo'].albedo
     m.integrate_years(1)
-    m.subprocess['SW'].add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
-    m.subprocess['SW'].albedo = m.subprocess['SW'].subprocess['albedo'].albedo
+    m.add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
+    m.subprocess['SW'].albedo = m.subprocess['albedo'].albedo
     m.integrate_years(1)
     assert np.all(m.icelat == np.array([-70.,  70.]))
-    assert np.all(m.icelat == m.subprocess['SW'].subprocess['albedo'].subprocess['iceline'].icelat)
+    assert np.all(m.icelat == m.subprocess['albedo'].subprocess['iceline'].icelat)
     #  What is the expected behavior if we swap out a subprocess for another
     #  and they have different diagnostics???
     #m.add_subprocess('albedo', albedo.ConstantAlbedo(state=m.state, **m.param))

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -86,14 +86,14 @@ def test_albedo():
     subprocess and get the expected icelat'''
     import numpy as np
     m = climlab.EBM()
-    m.add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
-    m.subprocess['SW'].albedo = m.subprocess['albedo'].albedo
+    m.subprocess['SW'].add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
+    m.subprocess['SW'].albedo = m.subprocess['SW'].subprocess['albedo'].albedo
     m.integrate_years(1)
-    m.add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
-    m.subprocess['SW'].albedo = m.subprocess['albedo'].albedo
+    m.subprocess['SW'].add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
+    m.subprocess['SW'].albedo = m.subprocess['SW'].subprocess['albedo'].albedo
     m.integrate_years(1)
     assert np.all(m.icelat == np.array([-70.,  70.]))
-    assert np.all(m.icelat == m.subprocess['albedo'].subprocess['iceline'].icelat)
+    assert np.all(m.icelat == m.subprocess['SW'].subprocess['albedo'].subprocess['iceline'].icelat)
     #  What is the expected behavior if we swap out a subprocess for another
     #  and they have different diagnostics???
     #m.add_subprocess('albedo', albedo.ConstantAlbedo(state=m.state, **m.param))

--- a/climlab/tests/test_ebm.py
+++ b/climlab/tests/test_ebm.py
@@ -60,7 +60,8 @@ def test_annual_iceline(EBM_iceline):
 def test_decreased_S0(EBM_iceline):
     '''Check that a decrease in solar constant to 1200 W/m2 will give a
     Snowball Earth result in the annual mean EBM.'''
-    EBM_iceline.subprocess['insolation'].S0 = 1200.
+    #EBM_iceline.subprocess['insolation'].S0 = 1200.
+    EBM_iceline.S0 = 1200.
     EBM_iceline.integrate_years(5.)
     assert np.all(EBM_iceline.icelat == np.array([-0.,  0.]))
 
@@ -85,10 +86,10 @@ def test_albedo():
     subprocess and get the expected icelat'''
     import numpy as np
     m = climlab.EBM()
-    m.add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
+    m.subprocess['SW'].add_subprocess('albedo', climlab.surface.ConstantAlbedo(state=m.state, **m.param))
     m.integrate_years(1)
     assert m.icelat == None
-    m.add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
+    m.subprocess['SW'].add_subprocess('albedo', climlab.surface.StepFunctionAlbedo(state=m.state, **m.param))
     m.integrate_years(1)
     assert np.all(m.icelat == np.array([-70.,  70.]))
     assert np.all(m.icelat == m.subprocess.albedo.subprocess.iceline.icelat)

--- a/climlab/tests/test_emanuel_convection.py
+++ b/climlab/tests/test_emanuel_convection.py
@@ -50,6 +50,7 @@ emanuel_convection.G=9.8
 emanuel_convection.ROWL=1000.0
 
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_convect_tendencies():
     # Temperatures in a single column
@@ -75,6 +76,7 @@ def test_convect_tendencies():
     assert FU == pytest.approx(tend['U'], rel=tol)
     assert FV == pytest.approx(tend['V'], rel=tol)
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_multidim_tendencies():
     # Same test just repeated in two parallel columns
@@ -105,6 +107,7 @@ def test_multidim_tendencies():
     assert np.tile(FU,(num_lat,1)) == pytest.approx(tend['U'], rel=tol)
     assert np.tile(FV,(num_lat,1)) == pytest.approx(tend['V'], rel=tol)
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_rcm_emanuel():
     num_lev = 30

--- a/climlab/tests/test_grey_radiation.py
+++ b/climlab/tests/test_grey_radiation.py
@@ -27,10 +27,8 @@ def rcmodel():
 @pytest.fixture()
 def diffmodel(rcmodel):
     diffmodel = climlab.process_like(rcmodel)
-    # thermal diffusivity in W/m**2/degC
-    D = 0.05
-    # meridional diffusivity in 1/s
-    K = D / diffmodel.Tatm.domain.heat_capacity[0]
+    # meridional diffusivity in m**2/s
+    K = 0.05 / diffmodel.Tatm.domain.heat_capacity[0] *  climlab.constants.a**2
     d = climlab.dynamics.MeridionalDiffusion(K=K,
                 state={'Tatm': diffmodel.state['Tatm']},
                 **diffmodel.param)

--- a/climlab/tests/test_insolation.py
+++ b/climlab/tests/test_insolation.py
@@ -62,8 +62,9 @@ def test_long_orbital_parameters():
 def test_orbital_cycles():
     ebm = EBM_seasonal()
     #  add an albedo feedback
-    albedo = StepFunctionAlbedo(state=ebm.state, **ebm.param)
-    ebm.add_subprocess('albedo', albedo)
+    alb = StepFunctionAlbedo(state=ebm.state, **ebm.param)
+    ebm.add_subprocess('albedo', alb)
+    ebm.subprocess['SW'].albedo = alb.albedo
     #  run for 1,000 orbital years, but only 100 model years
     experiment = OrbitalCycles(ebm, kyear_start=-20, kyear_stop=-19,
                                orbital_year_factor=10.)

--- a/climlab/tests/test_rcm.py
+++ b/climlab/tests/test_rcm.py
@@ -3,6 +3,7 @@ import numpy as np
 import climlab
 import pytest
 
+@pytest.mark.compiled
 @pytest.fixture()
 def rcm():
     # initial state (temperatures)
@@ -19,6 +20,7 @@ def rcm():
     rcm = climlab.couple([h2o,convadj,rad], name='RCM')
     return rcm
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_convective_adjustment(rcm):
     rcm.step_forward()

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -7,6 +7,7 @@ from climlab.tests.xarray_test import to_xarray
 
 num_lev = 30
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_rrtmg_lw_creation():
     state = climlab.column_state(num_lev=num_lev, water_depth=5.)
@@ -15,6 +16,7 @@ def test_rrtmg_lw_creation():
     assert np.all(_rrtm_to_climlab(_climlab_to_rrtm(rad.Ts)) == rad.Ts)
     assert np.all(_rrtm_to_climlab(_climlab_to_rrtm(rad.Tatm)) == rad.Tatm)
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_rrtm_creation():
     # initial state (temperatures)
@@ -31,6 +33,7 @@ def test_rrtm_creation():
     # Test the xarray interface
     to_xarray(rad)
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_swap_component():
     # initial state (temperatures)
@@ -45,6 +48,7 @@ def test_swap_component():
     rad.step_forward()
     assert hasattr(rad, 'OLR')
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_multidim():
     state = climlab.column_state(num_lev=40, num_lat=3, water_depth=5.)
@@ -56,6 +60,7 @@ def test_multidim():
     rad.step_forward()
     assert rad.OLR.shape == rad.Ts.shape
 
+@pytest.mark.compiled
 @pytest.mark.fast
 def test_cloud():
     '''Put a high cloud layer in a radiative model.
@@ -82,6 +87,7 @@ def test_cloud():
         assert(rad.ASR - rad.ASRclr < 0.)
         assert(rad.OLR - rad.OLRclr < 0.)
 
+@pytest.mark.compiled
 @pytest.mark.slow
 def test_radiative_forcing():
     '''Run a single-column radiative-convective model with RRTMG radiation
@@ -113,6 +119,7 @@ def test_radiative_forcing():
     #  Test the xarray interface
     to_xarray(rcm2)
 
+@pytest.mark.compiled
 @pytest.mark.slow
 def test_latitude():
     '''

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.6.dev1" %}
+{% set version = "0.6.6.dev2" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.6.dev4" %}
+{% set version = "0.6.6.dev5" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   path: ../
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.6.dev2" %}
+{% set version = "0.6.6.dev3" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.6.6.dev3" %}
+{% set version = "0.6.6.dev4" %}
 
 package:
   name: {{ name|lower }}

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -92,7 +92,13 @@ To run the full set of tests on the currently installed version of CLIMLAB, you 
 
 All tests should report ``PASSED``.
 
-CLIMLAB is a mix of pure Python and compiled Fortran. To fully test new code modifications, you will need to rebuild and install a new version. We use (and recommend) `conda build`_ to handle the dependencies including Fortran compiler.
+CLIMLAB is a mix of pure Python and compiled Fortran. If you are developing new code that does not rely on the compiled components, it is useful to run tests directly from the source code directory. From the ``climlab`` root directory, do the following::
+
+    pytest -v -m "not compiled"
+
+which excludes the tests marked as requiring the compiled components. Again, look for all tests to report ``PASSED``.
+
+If you are interacting with compiled components (e.g. RRTMG radiation), testing is a little more complicated. You will need to rebuild and install a new version. We use (and recommend) `conda build`_ to handle the dependencies including Fortran compiler.
 
 To build CLIMLAB, do this from the root directory of the CLIMLAB source repo::
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -96,7 +96,7 @@ CLIMLAB is a mix of pure Python and compiled Fortran. If you are developing new 
 
     pytest -v -m "not compiled"
 
-which excludes the tests marked as requiring the compiled components. Again, look for all tests to report ``PASSED``.
+which excludes the tests marked as requiring the compiled components. Again, look for all tests to report ``PASSED``. For more details see the `pytest`_ documentation.
 
 If you are interacting with compiled components (e.g. RRTMG radiation), testing is a little more complicated. You will need to rebuild and install a new version. We use (and recommend) `conda build`_ to handle the dependencies including Fortran compiler.
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.6.dev2'
+VERSION = '0.6.6.dev3'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.6.dev1'
+VERSION = '0.6.6.dev2'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.6.dev0'
+VERSION = '0.6.6.dev1'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.6.dev3'
+VERSION = '0.6.6.dev4'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.6.6.dev4'
+VERSION = '0.6.6.dev5'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,


### PR DESCRIPTION
Lots of internal reorganization to modernize the EBM implementation and add a moist diffusion process:

- `climlab.dynamics.Diffusion` and its subclasses are improved:
    - automatically computes flux and flux convergence diagnostics
    - The diffusivity `K` can be freely adjusted by the user; the diffusivity matrix is automatically recomputed.
    - New subclass `MeridionalHeatDiffusion` is tailor-made for dry EBMs and automatically computes flux diagnostics in the appropriate units (PW and W/m2)
    - A brand new class for diffusion on moist static energy gradients (moist EBM): `climlab.dynamics.MeridionalMoistDiffusion`
- `climlab.EBM()` and its daughter classes are significantly reorganized to better respect CLIMLAB principles:
    - Essentially all the computations are done by subprocesses
    - SW radiation is now handled by `SimpleAbsorbedShortwave` class 
    - Diffusion and its diagnostics now handled by `MeridionalHeatDiffusion` class.
- tests that require compiled code are now marked with `pytest.mark.compiled` for easy exclusion during local development
- some new tests including a basic test to construct the moist EBM by replacing dry diffusion with moist diffusion.

Includes some **breaking API changes**:

- `compute()` method now always returns tendency dictionaries
- The `heat_transport()` and `heat_tranpsort_convergence()` methods of `climlab.EBM` (and its subclasses) have been removed and replaced by diagnostics of the same name (but accessed without the parentheses).
- Diffusivity input value `K` in class `climlab.dynamics.MeridionalDiffusion` is now specified in physical units of m**2 / s instead of (1/s). This is consistent with its parent class `climlab.dynamics.Diffusion`.