### PR TITLE
Implement ozone_file=None option

### DIFF
--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.7.1.dev0'
+__version__ = '0.7.1.dev1'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -165,3 +165,4 @@ def test_no_ozone():
     lev.delta = np.abs(np.diff(lev.bounds))
     #  Create a RRTM radiation model
     rad = climlab.radiation.RRTMG(state=state, ozone_file=None)
+    assert np.all(rad.absorber_vmr['O3']==0.)

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -150,3 +150,18 @@ def test_latitude():
     grad = np.diff(model.Ts, axis=0)
     assert np.all(grad[0:(int(num_lat/2)-1)] > 0.)
     assert np.all(grad[int(num_lat/2):] < 0.)
+
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_no_ozone():
+    '''When user gives None as the ozone_file, the model is initialized
+    with zero ozone. This should work on arbitrary grids.'''
+    ps = 1060.
+    num_lev=4000
+    state = climlab.column_state(num_lev=num_lev, num_lat=1, water_depth=5.)
+    lev = state.Tatm.domain.lev
+    lev.bounds = np.linspace(0., ps, num_lev+1)
+    lev.points = lev.bounds[:-1] + np.diff(lev.bounds)/2.
+    lev.delta = np.abs(np.diff(lev.bounds))
+    #  Create a RRTM radiation model
+    rad = climlab.radiation.RRTMG(state=state, ozone_file=None)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "climlab" %}
-{% set version = "0.7.1.dev0" %}
+{% set version = "0.7.1.dev1" %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.7.1.dev0'
+VERSION = '0.7.1.dev1'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,


### PR DESCRIPTION
This implements a new option to set 
```
ozone_file=None
```
as input to radiation processes, e.g. RRTMG.

This flag, in conjunction with ```absorber_vmr=None``` will initialize the process with zero ozone.

This fixes #70, allowing the user to set whatever ozone values they want after creating the process object.