### PR TITLE
Fix broadcasting error for fixed insolation

### DIFF
--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.7.2.dev0'
+__version__ = '0.7.2.dev1'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants, thermo, legendre

--- a/climlab/radiation/rrtm/rrtmg_lw.py
+++ b/climlab/radiation/rrtm/rrtmg_lw.py
@@ -4,7 +4,7 @@ import warnings
 from climlab import constants as const
 from climlab.radiation.radiation import _Radiation_LW
 from .utils import _prepare_general_arguments
-from .utils import _climlab_to_rrtm, _climlab_to_rrtm_sfc, _rrtm_to_climlab
+from .utils import _climlab_to_rrtm, _rrtm_to_climlab
 # These values will get overridden by reading from Fortran extension
 nbndlw = 1; ngptlw = 1;
 try:

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -143,11 +143,11 @@ class RRTMG_SW(_Radiation_SW):
         cfc12vmr, cfc12vmr, cfc22vmr, ccl4vmr,
         cldfrac, ciwp, clwp, relq, reic) = _prepare_general_arguments(self)
 
-        aldif = _climlab_to_rrtm_sfc(self.aldif * np.ones_like(self.Ts))
-        aldir = _climlab_to_rrtm_sfc(self.aldir * np.ones_like(self.Ts))
-        asdif = _climlab_to_rrtm_sfc(self.asdif * np.ones_like(self.Ts))
-        asdir = _climlab_to_rrtm_sfc(self.asdir * np.ones_like(self.Ts))
-        coszen = _climlab_to_rrtm_sfc(self.coszen * np.ones_like(self.Ts))
+        aldif = _climlab_to_rrtm_sfc(self.aldif, self.Ts)
+        aldir = _climlab_to_rrtm_sfc(self.aldir, self.Ts)
+        asdif = _climlab_to_rrtm_sfc(self.asdif, self.Ts)
+        asdir = _climlab_to_rrtm_sfc(self.asdir, self.Ts)
+        coszen = _climlab_to_rrtm_sfc(self.coszen, self.Ts)
         #  These arrays have an extra dimension for number of bands
         # in-cloud optical depth [nbndsw,ncol,nlay]
         tauc = _climlab_to_rrtm(self.tauc * np.ones_like(self.Tatm))

--- a/climlab/radiation/rrtm/utils.py
+++ b/climlab/radiation/rrtm/utils.py
@@ -11,7 +11,7 @@ def _prepare_general_arguments(RRTMGobject):
     play = _climlab_to_rrtm(RRTMGobject.lev * np.ones_like(tlay))
     plev = _climlab_to_rrtm(RRTMGobject.lev_bounds * np.ones_like(tlev))
     ncol, nlay = tlay.shape
-    tsfc = _climlab_to_rrtm_sfc(RRTMGobject.Ts)
+    tsfc = _climlab_to_rrtm_sfc(RRTMGobject.Ts, RRTMGobject.Ts)
     # GASES -- put them in proper dimensions and units
     vapor_mixing_ratio = mmr_to_vmr(RRTMGobject.specific_humidity, gas='H2O')
     h2ovmr   = _climlab_to_rrtm(vapor_mixing_ratio * np.ones_like(RRTMGobject.Tatm))
@@ -97,10 +97,8 @@ def _rrtm_to_climlab(field):
             raise ValueError('field must be array_like or scalar.')
     return np.squeeze(field)
 
-def _climlab_to_rrtm_sfc(field):
-    if len(field.shape)==1:
-        return field  #  single column
-    elif len(field.shape)==2:
-        return np.squeeze(field)  # should handle case with num_lat > 1
-    else:
-        raise ValueError('Mix up with dimensions of surface field')
+def _climlab_to_rrtm_sfc(field, Ts):
+    '''Return an array of size np.squeeze(Ts) to remove the singleton depth dimension'''
+    fieldsqueeze = np.squeeze(field)
+    Tsqueeze = np.squeeze(Ts)
+    return fieldsqueeze * np.ones_like(Tsqueeze)

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -167,15 +167,13 @@ def test_no_ozone():
     rad = climlab.radiation.RRTMG(state=state, ozone_file=None)
     assert np.all(rad.absorber_vmr['O3']==0.)
 
-@pytest.mark.compiled
-@pytest.mark.fast
-def test_fixed_insolation():
+# @pytest.mark.compiled
+# @pytest.mark.fast
+# def test_fixed_insolation():
     '''Make sure that we can run a model forward with specified time-invariant insolation'''
     num_lat = 4; num_lev = 20   # grid size
     day_of_year = 80.  # days since Jan 1
-    import climlab
-    import numpy as np
-    lat = np.linspace(-90., 90., num_lat)
+    lat = np.linspace(-80., 80., num_lat)
     state = climlab.column_state(num_lev=num_lev, lat=lat)
     insolation = climlab.solar.insolation.daily_insolation(lat=lat, day=day_of_year)
     ins_array = insolation.values

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -167,9 +167,9 @@ def test_no_ozone():
     rad = climlab.radiation.RRTMG(state=state, ozone_file=None)
     assert np.all(rad.absorber_vmr['O3']==0.)
 
-# @pytest.mark.compiled
-# @pytest.mark.fast
-# def test_fixed_insolation():
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_fixed_insolation():
     '''Make sure that we can run a model forward with specified time-invariant insolation'''
     num_lat = 4; num_lev = 20   # grid size
     day_of_year = 80.  # days since Jan 1

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -166,3 +166,18 @@ def test_no_ozone():
     #  Create a RRTM radiation model
     rad = climlab.radiation.RRTMG(state=state, ozone_file=None)
     assert np.all(rad.absorber_vmr['O3']==0.)
+
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_fixed_insolation():
+    '''Make sure that we can run a model forward with specified time-invariant insolation'''
+    num_lat = 4; num_lev = 20   # grid size
+    day_of_year = 80.  # days since Jan 1
+    import climlab
+    import numpy as np
+    lat = np.linspace(-90., 90., num_lat)
+    state = climlab.column_state(num_lev=num_lev, lat=lat)
+    insolation = climlab.solar.insolation.daily_insolation(lat=lat, day=day_of_year)
+    ins_array = insolation.values
+    rad = climlab.radiation.RRTMG(name='Radiation', state=state, insolation=ins_array)
+    rad.step_forward()

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.2.dev0" %}
+{% set version = "0.7.2.dev1" %}
 
 package:
   name: climlab

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.7.2.dev0'
+VERSION = '0.7.2.dev1'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,


### PR DESCRIPTION
This should close #90 and #89. The workaround suggested in #90 will no longer be needed.

Add a simple test for an RRTMG process with insolation specified on a latitude grid for a specific day of the year.

Make the conversion routine `_climlab_to_rrtm_sfc` more robust to broadcasting errors.

Before merging this, it would be good to add an example to the docs.