### PR TITLE
Fix interpolation

### DIFF
--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.7.2.dev1'
+__version__ = '0.7.2.dev2'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants, thermo, legendre

--- a/climlab/radiation/radiation.py
+++ b/climlab/radiation/radiation.py
@@ -154,8 +154,7 @@ def default_absorbers(Tatm,
             # There will be NaNs for gridpoints outside the ozone file domain
             assert not np.any(np.isnan(O3))
         except:
-            warnings.warn('Some grid points are beyond the bounds of the ozone file. Ozone values will be extrapolated.',
-                        FutureWarning, stacklevel=2)
+            warnings.warn('Some grid points are beyond the bounds of the ozone file. Ozone values will be extrapolated.')
             try:
                 # passing fill_value=None to the underlying scipy interpolator
                 # will result in extrapolation instead of NaNs

--- a/climlab/tests/test_rrtm.py
+++ b/climlab/tests/test_rrtm.py
@@ -179,3 +179,13 @@ def test_fixed_insolation():
     ins_array = insolation.values
     rad = climlab.radiation.RRTMG(name='Radiation', state=state, insolation=ins_array)
     rad.step_forward()
+
+@pytest.mark.compiled
+@pytest.mark.fast
+def test_large_grid():
+    num_lev = 50; num_lat=90
+    state = climlab.column_state(num_lev=num_lev, num_lat=num_lat, water_depth=10.)
+    rad1 = climlab.radiation.CAM3(state=state)
+    rad1.step_forward()
+    rad2 = climlab.radiation.RRTMG(state=state)
+    rad2.step_forward()

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.2.dev1" %}
+{% set version = "0.7.2.dev2" %}
 
 package:
   name: climlab

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os, sys
 import textwrap
 
-VERSION = '0.7.2.dev1'
+VERSION = '0.7.2.dev2'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,


### PR DESCRIPTION
This should close #95 

When initializing Radiation objects, the ozone interpolation now checks to see if there are any NaNs caused by grid points beyond the bound of the ozone file. 

If NaNs are found, a warning is issued and the interpolation is redone using scipy's option to extrapolate to out-of-bounds values.

A test of CAM3 and RRTMG processes on large 2D grids is added.