### PR TITLE
dependencies in setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "numpy",
+]

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,7 @@ def setup_package():
           author='Brian E. J. Rose',
           author_email='brose@albany.edu',
           setup_requires=['numpy'],
-          install_requires=['numpy'],
-          requires=['xarray','attrdict','scipy'],
+          install_requires=['numpy','xarray','attrdict','scipy'],
           license='MIT',
     )
     run_build = True

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,8 @@ def setup_package():
           url='http://github.com/brian-rose/climlab',
           author='Brian E. J. Rose',
           author_email='brose@albany.edu',
+          install_requires=['numpy'],
+          requires=['xarray','attrdict','scipy'],
           license='MIT',
     )
     run_build = True

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ def patch_fortran():
         from numpy.distutils import fcompiler
     except ImportError:
         import sys
+        from __future__ import print_function
         print("\nPlease install numpy before installing climlab\n", file=sys.stderr)
         sys.exit(-1)
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
 VERSION = '0.7.5'
@@ -19,7 +20,6 @@ def patch_fortran():
         from numpy.distutils import fcompiler
     except ImportError:
         import sys
-        from __future__ import print_function
         print("\nPlease install numpy before installing climlab\n", file=sys.stderr)
         sys.exit(-1)
 
@@ -69,6 +69,7 @@ def setup_package():
           url='http://github.com/brian-rose/climlab',
           author='Brian E. J. Rose',
           author_email='brose@albany.edu',
+          setup_requires=['numpy'],
           install_requires=['numpy'],
           requires=['xarray','attrdict','scipy'],
           license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,12 @@ def readme():
 # Patch the Fortran compiler not to optimize certain sources
 def patch_fortran():
     # This should work for all subclasses of FCompiler
-    from numpy.distutils import fcompiler
+    try:
+        from numpy.distutils import fcompiler
+    except ImportError:
+        import sys
+        print("\nPlease install numpy before installing climlab\n", file=sys.stderr)
+        sys.exit(-1)
 
     def monkeypatched_spawn(old_spawn):
         def spawn(self, cmd, *args, **kw):


### PR DESCRIPTION
Adding dependencies to setup.py and adding an error message if numpy is not already installed, as it's used before the install_requires can trigger. This isn't really optimal, but I'm not 100% sure how this issue would be solved properly. With a requirements file maybe?