### PR TITLE
Adds timeout to download

### DIFF
--- a/climlab/utils/data_source.py
+++ b/climlab/utils/data_source.py
@@ -93,7 +93,7 @@ def merge_two_dicts(x, y):
 
 def _download_and_cache(source, local_path):
     import requests
-    resp = requests.get(source, allow_redirects=True)
+    resp = requests.get(source, allow_redirects=True, timeout=300)
     if resp.status_code == 200:  # successful http request
         with open(local_path, 'wb') as file:
             file.write(resp.content)


### PR DESCRIPTION
For #116, I added a timeout in the `request.get`. 

Adds a 5 minute timeout error for the download of remote files. For more information regarding `requests.get`, see here: https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts