### PR TITLE
WIP: custom physical constants for each process

### DIFF
--- a/climlab/convection/akmaev_adjustment.py
+++ b/climlab/convection/akmaev_adjustment.py
@@ -1,6 +1,6 @@
 from __future__ import division
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 import sys
 
 

--- a/climlab/convection/convadj.py
+++ b/climlab/convection/convadj.py
@@ -1,7 +1,7 @@
 from __future__ import division
 from builtins import range
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.utils.thermo import rho_moist, pseudoadiabat
 from climlab.process.time_dependent_process import TimeDependentProcess
 from climlab.domain.field import Field

--- a/climlab/convection/emanuel_convection.py
+++ b/climlab/convection/emanuel_convection.py
@@ -7,7 +7,7 @@ import numpy as np
 import warnings
 from climlab.process import TimeDependentProcess
 from climlab.utils.thermo import qsat
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 try:
     from ._emanuel_convection import emanuel_convection as convect
 except:
@@ -111,7 +111,7 @@ class EmanuelConvection(TimeDependentProcess):
 
                 import numpy as np
                 import climlab
-                from climlab import constants as const
+                from climlab.utils.constants import const_dict as const
                 # Temperatures in a single column
                 full_state = climlab.column_state(num_lev=30, water_depth=2.5)
                 temperature_state = {'Tatm':full_state.Tatm,'Ts':full_state.Ts}

--- a/climlab/domain/axis.py
+++ b/climlab/domain/axis.py
@@ -2,7 +2,7 @@ from __future__ import division
 from builtins import str
 from builtins import object
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 
 
 axis_types = ['lev', 'lat', 'lon', 'depth', 'abstract']

--- a/climlab/dynamics/meridional_advection_diffusion.py
+++ b/climlab/dynamics/meridional_advection_diffusion.py
@@ -35,7 +35,6 @@ will operate along the latitude dimension only.
 from __future__ import division
 import numpy as np
 from .advection_diffusion import AdvectionDiffusion, Diffusion
-from climlab.utils.constants import const_dict as const
 
 
 class MeridionalAdvectionDiffusion(AdvectionDiffusion):
@@ -52,8 +51,8 @@ class MeridionalAdvectionDiffusion(AdvectionDiffusion):
         # Conversion of delta from degrees (grid units) to physical length units
         phi_stag = np.deg2rad(self.lat_bounds)
         phi = np.deg2rad(self.lat)
-        self._Xcenter[...,:] = phi*const.a
-        self._Xbounds[...,:] = phi_stag*const.a
+        self._Xcenter[...,:] = phi*self.const.a
+        self._Xbounds[...,:] = phi_stag*self.const.a
         self._weight_bounds[...,:] = np.cos(phi_stag)
         self._weight_center[...,:] = np.cos(phi)
         #  Now properly compute the weighted advection-diffusion matrix

--- a/climlab/dynamics/meridional_advection_diffusion.py
+++ b/climlab/dynamics/meridional_advection_diffusion.py
@@ -35,7 +35,7 @@ will operate along the latitude dimension only.
 from __future__ import division
 import numpy as np
 from .advection_diffusion import AdvectionDiffusion, Diffusion
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 
 
 class MeridionalAdvectionDiffusion(AdvectionDiffusion):

--- a/climlab/dynamics/meridional_heat_diffusion.py
+++ b/climlab/dynamics/meridional_heat_diffusion.py
@@ -38,7 +38,6 @@ will operate along the latitude dimension only.
 from __future__ import division
 import numpy as np
 from .meridional_advection_diffusion import MeridionalDiffusion
-from climlab.utils.constants import const_dict as const
 
 
 class MeridionalHeatDiffusion(MeridionalDiffusion):
@@ -87,7 +86,7 @@ class MeridionalHeatDiffusion(MeridionalDiffusion):
         for varname, value in self.state.items():
             heat_capacity = value.domain.heat_capacity
         # diffusivity in units of m**2/s
-        self.K = self.D / heat_capacity * const.a**2
+        self.K = self.D / heat_capacity * self.const.a**2
 
     def _update_diagnostics(self, newstate):
         super(MeridionalHeatDiffusion, self)._update_diagnostics(newstate)
@@ -95,6 +94,6 @@ class MeridionalHeatDiffusion(MeridionalDiffusion):
             heat_capacity = value.domain.heat_capacity
         coslat_bounds = np.moveaxis(self._weight_bounds,-1,self.diffusion_axis_index)
         self.heat_transport[:] = (self.diffusive_flux * heat_capacity *
-            2 * np.pi * const.a * coslat_bounds * 1E-15) # in PW
+            2 * np.pi * self.const.a * coslat_bounds * 1E-15) # in PW
         self.heat_transport_convergence[:] = (self.flux_convergence *
                         heat_capacity)  # in W/m**2

--- a/climlab/dynamics/meridional_heat_diffusion.py
+++ b/climlab/dynamics/meridional_heat_diffusion.py
@@ -38,7 +38,7 @@ will operate along the latitude dimension only.
 from __future__ import division
 import numpy as np
 from .meridional_advection_diffusion import MeridionalDiffusion
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 
 
 class MeridionalHeatDiffusion(MeridionalDiffusion):

--- a/climlab/dynamics/meridional_moist_diffusion.py
+++ b/climlab/dynamics/meridional_moist_diffusion.py
@@ -120,7 +120,7 @@ from __future__ import division
 import numpy as np
 from .meridional_heat_diffusion import MeridionalHeatDiffusion
 from climlab.utils.thermo import qsat
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 
 
 class MeridionalMoistDiffusion(MeridionalHeatDiffusion):

--- a/climlab/dynamics/meridional_moist_diffusion.py
+++ b/climlab/dynamics/meridional_moist_diffusion.py
@@ -131,10 +131,10 @@ class MeridionalMoistDiffusion(MeridionalHeatDiffusion):
 
     def _update_diffusivity(self):
         Tinterp = np.interp(self.lat_bounds, self.lat, np.squeeze(self.Ts))
-        Tkelvin = Tinterp + const.tempCtoK
-        f = moist_amplification_factor(Tkelvin, self.relative_humidity)
+        Tkelvin = Tinterp + self.const.tempCtoK
+        f = moist_amplification_factor(Tkelvin, self.relative_humidity, self.const)
         heat_capacity = self.Ts.domain.heat_capacity
-        self.K = self.D / heat_capacity * const.a**2 * (1+f)
+        self.K = self.D / heat_capacity * self.const.a**2 * (1+f)
 
     def _implicit_solver(self):
         self._update_diffusivity()
@@ -142,10 +142,11 @@ class MeridionalMoistDiffusion(MeridionalHeatDiffusion):
         return super(MeridionalMoistDiffusion, self)._implicit_solver()
 
 
-def moist_amplification_factor(Tkelvin, relative_humidity=0.8):
+def moist_amplification_factor(Tkelvin, relative_humidity=0.8, constants=const):
     '''Compute the moisture amplification factor for the moist diffusivity
     given relative humidity and reference temperature profile.'''
     deltaT = 0.01
     #  slope of saturation specific humidity at 1000 hPa
-    dqsdTs = (qsat(Tkelvin+deltaT/2, 1000.) - qsat(Tkelvin-deltaT/2, 1000.)) / deltaT
-    return const.Lhvap / const.cp * relative_humidity * dqsdTs
+    dqsdTs = (qsat(Tkelvin+deltaT/2, 1000., constants=constants) -
+                qsat(Tkelvin-deltaT/2, 1000., constants=constants)) / deltaT
+    return constants.Lhvap / constants.cp * relative_humidity * dqsdTs

--- a/climlab/model/column.py
+++ b/climlab/model/column.py
@@ -36,7 +36,7 @@ calculated for 45N.
 """
 from __future__ import division
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.process.time_dependent_process import TimeDependentProcess
 from climlab.domain.initial import column_state
 from climlab.domain.field import Field

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -78,7 +78,7 @@ We can run both models out to equilibrium and compare the results as follows:
 """
 from __future__ import division
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.domain.field import Field, global_mean
 from climlab.process import EnergyBudget, TimeDependentProcess
 from climlab.utils import legendre

--- a/climlab/model/ebm.py
+++ b/climlab/model/ebm.py
@@ -261,14 +261,16 @@ class EBM(TimeDependentProcess):
         self.param['a2'] = a2
         self.param['ai'] = ai
         # create sub-models
-        lw = AplusBT(state=self.state, **self.param)
-        ins = P2Insolation(domains=sfc, **self.param)
-        alb = albedo.StepFunctionAlbedo(state=self.state, **self.param)
+        lw = AplusBT(state=self.state, const=self.const, **self.param)
+        ins = P2Insolation(domains=sfc, const=self.const, **self.param)
+        alb = albedo.StepFunctionAlbedo(state=self.state, const=self.const, **self.param)
         sw = SimpleAbsorbedShortwave(state=self.state,
                                      insolation=ins.insolation,
                                      albedo=alb.albedo,
+                                     const=self.const,
                                      **self.param)
-        diff = MeridionalHeatDiffusion(state=self.state, use_banded_solver=False, **self.param)
+        diff = MeridionalHeatDiffusion(state=self.state, const=self.const,
+                                       use_banded_solver=False, **self.param)
         self.add_subprocess('LW', lw)
         self.add_subprocess('insolation', ins)
         self.add_subprocess('albedo', alb)
@@ -333,7 +335,7 @@ class EBM(TimeDependentProcess):
         """
         phi = np.deg2rad(self.lat)
         energy_in = np.squeeze(self.net_radiation)
-        return (1E-15 * 2 * np.math.pi * const.a**2 *
+        return (1E-15 * 2 * np.math.pi * self.const.a**2 *
                 integrate.cumtrapz(np.cos(phi)*energy_in, x=phi, initial=0.))
 
     # def heat_transport(self):
@@ -370,7 +372,7 @@ class EBM(TimeDependentProcess):
         dTdphi = np.diff(T) / np.diff(phi)
         dTdphi = np.append(dTdphi, 0.)
         dTdphi = np.insert(dTdphi, 0, 0.)
-        return (1E-15*-2*np.math.pi*np.cos(phi_stag)*const.a**2*D*dTdphi)
+        return (1E-15*-2*np.math.pi*np.cos(phi_stag)*self.const.a**2*D*dTdphi)
 
     # def heat_transport_convergence(self):
     #     """Returns instantaneous convergence of heat transport.

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -72,6 +72,7 @@ from climlab.domain.domain import _Domain, zonal_mean_surface
 from climlab.utils import walk
 from attrdict import AttrDict
 from climlab.domain.xarray import state_to_xarray
+from climlab.utils.constants import const_dict as const
 
 
 def _make_dict(arg, argtype):
@@ -145,10 +146,13 @@ class Process(object):
 
     def __init__(self, name='Untitled', state=None, domains=None, subprocess=None,
                  lat=None, lev=None, num_lat=None, num_levels=None,
-                 input=None, verbose=True, **kwargs):
+                 input=None, verbose=True,
+                 const=const,
+                 **kwargs):
         # verbose flag used to control text output at process creation time
         self.verbose = verbose
         self.name = name
+        self.const = const
         # dictionary of domains. Keys are the domain names
         self.domains = _make_dict(domains, _Domain)
         #  If lat is given, create a simple domains

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -4,7 +4,7 @@ from builtins import str
 from builtins import range
 import numpy as np
 import copy
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from .process import Process
 from climlab.utils import walk
 from attrdict import AttrDict

--- a/climlab/radiation/absorbed_shorwave.py
+++ b/climlab/radiation/absorbed_shorwave.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function
 from climlab.process.energy_budget import EnergyBudget
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 
 
 class SimpleAbsorbedShortwave(EnergyBudget):

--- a/climlab/radiation/aplusbt.py
+++ b/climlab/radiation/aplusbt.py
@@ -1,6 +1,6 @@
 from __future__ import division
 from climlab.process.energy_budget import EnergyBudget
-from climlab.utils import constants as const
+from climlab.utils.constants import const_dict as const
 import numpy as np
 
 

--- a/climlab/radiation/boltzmann.py
+++ b/climlab/radiation/boltzmann.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.process.energy_budget import EnergyBudget
 
 

--- a/climlab/radiation/cam3/cam3.py
+++ b/climlab/radiation/cam3/cam3.py
@@ -34,7 +34,7 @@ Input arguments and diagnostics follow specifications in
 '''
 from __future__ import division, print_function, absolute_import
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.utils.thermo import vmr_to_mmr
 from climlab.radiation.radiation import _Radiation_SW, _Radiation_LW
 from climlab.utils.data_source import load_data_source

--- a/climlab/radiation/insolation.py
+++ b/climlab/radiation/insolation.py
@@ -22,7 +22,7 @@ from climlab.process.diagnostic import DiagnosticProcess
 from climlab.domain.field import Field
 from climlab.domain.field import to_latlon
 from climlab.utils.legendre import P2
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.solar.insolation import daily_insolation
 
 # REVISE TO MAKE ALL OF THESE CALLABLE WITH NO ARGUMENTS.

--- a/climlab/radiation/nband.py
+++ b/climlab/radiation/nband.py
@@ -2,7 +2,7 @@ from __future__ import division
 from builtins import range
 import numpy as np
 from climlab.radiation.greygas import GreyGas
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.domain import domain, axis, field
 from copy import copy
 

--- a/climlab/radiation/radiation.py
+++ b/climlab/radiation/radiation.py
@@ -76,7 +76,7 @@ from __future__ import print_function
 import numpy as np
 from climlab.process import EnergyBudget
 from climlab.radiation import ManabeWaterVapor
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.domain.field import Field
 from climlab.utils.data_source import load_data_source
 import warnings

--- a/climlab/radiation/rrtm/rrtmg.py
+++ b/climlab/radiation/rrtm/rrtmg.py
@@ -1,7 +1,7 @@
 from __future__ import division
 from __future__ import absolute_import
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.radiation.radiation import _Radiation_SW, _Radiation_LW
 from .rrtmg_lw import RRTMG_LW
 from .rrtmg_sw import RRTMG_SW, nbndsw

--- a/climlab/radiation/rrtm/rrtmg_lw.py
+++ b/climlab/radiation/rrtm/rrtmg_lw.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 import numpy as np
 import warnings
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.radiation.radiation import _Radiation_LW
 from .utils import _prepare_general_arguments
 from .utils import _climlab_to_rrtm, _rrtm_to_climlab

--- a/climlab/radiation/rrtm/rrtmg_sw.py
+++ b/climlab/radiation/rrtm/rrtmg_sw.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 import numpy as np
 import warnings
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.radiation.radiation import _Radiation_SW
 from .utils import _prepare_general_arguments
 from .utils import _climlab_to_rrtm, _climlab_to_rrtm_sfc, _rrtm_to_climlab

--- a/climlab/radiation/water_vapor.py
+++ b/climlab/radiation/water_vapor.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import numpy as np
 from climlab.process.diagnostic import DiagnosticProcess
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.utils.thermo import clausius_clapeyron
 
 

--- a/climlab/solar/insolation.py
+++ b/climlab/solar/insolation.py
@@ -38,7 +38,7 @@ following :cite:`Berger_1978`. Further references: :cite:`Berger_1991`.
 
 from __future__ import division
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from numpy import sqrt, deg2rad, rad2deg, sin, cos, tan, arcsin, arccos, pi
 import xarray as xr
 

--- a/climlab/solar/orbital_cycles.py
+++ b/climlab/solar/orbital_cycles.py
@@ -4,7 +4,7 @@ from builtins import str
 from builtins import range
 from builtins import object
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.solar.orbital import OrbitalTable
 from climlab.domain.field import global_mean
 

--- a/climlab/surface/turbulent.py
+++ b/climlab/surface/turbulent.py
@@ -16,7 +16,7 @@ occurs in the lowest atmospheric model level.
 
                 import numpy as np
                 import climlab
-                from climlab import constants as const
+                from climlab.utils.constants import const_dict as const
                 # Temperatures in a single column
                 full_state = climlab.column_state(num_lev=30, water_depth=2.5)
                 temperature_state = {'Tatm':full_state.Tatm,'Ts':full_state.Ts}
@@ -57,7 +57,7 @@ occurs in the lowest atmospheric model level.
 from __future__ import division
 import numpy as np
 from climlab.utils.thermo import qsat
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.process.energy_budget import EnergyBudget
 from climlab.domain.field import Field
 

--- a/climlab/tests/test_emanuel_convection.py
+++ b/climlab/tests/test_emanuel_convection.py
@@ -3,6 +3,7 @@ import numpy as np
 import climlab
 from climlab.convection import emanuel_convection
 from climlab.tests.xarray_test import to_xarray
+from climlab.utils.constants import const_dict as const
 import pytest
 
 
@@ -117,7 +118,7 @@ def test_rcm_emanuel():
     #  Initialize a nearly dry column (small background stratospheric humidity)
     state['q'] = np.ones_like(state.Tatm) * 5.E-6
     #  ASYNCHRONOUS COUPLING -- the radiation uses a much longer timestep
-    short_timestep = climlab.constants.seconds_per_hour
+    short_timestep = const.seconds_per_hour
     #  The top-level model
     model = climlab.TimeDependentProcess(name='Radiative-Convective Model',
                         state=state,
@@ -135,7 +136,7 @@ def test_rcm_emanuel():
     #  Surface heat flux processes
     shf = climlab.surface.SensibleHeatFlux(name='SHF',
                                   state=state, Cd=0.5E-3,
-                                  timestep=climlab.constants.seconds_per_hour)
+                                  timestep=const.seconds_per_hour)
     lhf = climlab.surface.LatentHeatFlux(name='LHF',
                                   state=state, Cd=0.5E-3,
                                   timestep=short_timestep)

--- a/climlab/tests/test_grey_radiation.py
+++ b/climlab/tests/test_grey_radiation.py
@@ -3,7 +3,7 @@ import numpy as np
 import climlab
 import pytest
 from climlab.tests.xarray_test import to_xarray
-
+from climlab.utils.constants import const_dict as const
 
 @pytest.fixture()
 def model():
@@ -28,7 +28,7 @@ def rcmodel():
 def diffmodel(rcmodel):
     diffmodel = climlab.process_like(rcmodel)
     # meridional diffusivity in m**2/s
-    K = 0.05 / diffmodel.Tatm.domain.heat_capacity[0] *  climlab.constants.a**2
+    K = 0.05 / diffmodel.Tatm.domain.heat_capacity[0] *  const.a**2
     d = climlab.dynamics.MeridionalDiffusion(K=K,
                 state={'Tatm': diffmodel.state['Tatm']},
                 **diffmodel.param)

--- a/climlab/tests/test_insolation.py
+++ b/climlab/tests/test_insolation.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 import numpy as np
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 from climlab.solar.insolation import daily_insolation
 from climlab.solar.orbital import OrbitalTable
 from climlab.solar.orbital.long import OrbitalTable as LongOrbitalTable

--- a/climlab/utils/constants.py
+++ b/climlab/utils/constants.py
@@ -12,70 +12,73 @@
 
 from __future__ import division
 from numpy import pi
+from attrdict import AttrDict
 
-a = 6.373E6      # Radius of Earth (m)
-Lhvap = 2.5E6    # Latent heat of vaporization (J / kg)
-Lhsub = 2.834E6   # Latent heat of sublimation (J / kg)
-Lhfus = Lhsub - Lhvap  # Latent heat of fusion (J / kg)
-cp = 1004.     # specific heat at constant pressure for dry air (J / kg / K)
-Rd = 287.         # gas constant for dry air (J / kg / K)
-kappa = Rd / cp
-Rv = 461.5       # gas constant for water vapor (J / kg / K)
-cpv = 1875.   # specific heat at constant pressure for water vapor (J / kg / K)
-eps = Rd / Rv
-Omega = 2 * pi / 24. / 3600.  # Earth's rotation rate, (s**(-1))
-g = 9.8          # gravitational acceleration (m / s**2)
-kBoltzmann = 1.3806488E-23  # the Boltzmann constant (J / K)
-c_light = 2.99792458E8   # speed of light (m/s)
-hPlanck = 6.62606957E-34  # Planck's constant (J s)
+const_dict = AttrDict()
+
+const_dict['a'] = 6.373E6      # Radius of Earth (m)
+const_dict['Lhvap'] = 2.5E6    # Latent heat of vaporization (J / kg)
+const_dict['Lhsub'] = 2.834E6   # Latent heat of sublimation (J / kg)
+const_dict['Lhfus'] = const_dict['Lhsub'] - const_dict['Lhvap']  # Latent heat of fusion (J / kg)
+const_dict['cp'] = 1004.     # specific heat at constant pressure for dry air (J / kg / K)
+const_dict['Rd'] = 287.         # gas constant for dry air (J / kg / K)
+const_dict['kappa'] = const_dict['Rd'] / const_dict['cp']
+const_dict['Rv'] = 461.5       # gas constant for water vapor (J / kg / K)
+const_dict['cpv'] = 1875.   # specific heat at constant pressure for water vapor (J / kg / K)
+const_dict['eps'] = const_dict['Rd'] / const_dict['Rv']
+const_dict['Omega'] = 2 * pi / 24. / 3600.  # Earth's rotation rate, (s**(-1))
+const_dict['g'] = 9.8          # gravitational acceleration (m / s**2)
+const_dict['kBoltzmann'] = 1.3806488E-23  # the Boltzmann constant (J / K)
+const_dict['c_light'] = 2.99792458E8   # speed of light (m/s)
+const_dict['hPlanck'] = 6.62606957E-34  # Planck's constant (J s)
 #  Stefan-Boltzmann constant (W / m**2 / K**4) derived from fundamental constants
-sigma = (2*pi**5 * kBoltzmann**4) / (15 * c_light**2 * hPlanck**3)
+const_dict['sigma'] = (2*pi**5 * const_dict['kBoltzmann']**4) / (15 * const_dict['c_light']**2 * const_dict['hPlanck']**3)
 
-S0 = 1365.2       # solar constant (W / m**2)
+const_dict['S0'] = 1365.2       # solar constant (W / m**2)
 # value is consistent with Trenberth and Fasullo, Surveys of Geophysics 2012
 
-ps = 1000.       # approximate surface pressure (mb or hPa)
+const_dict['ps'] = 1000.       # approximate surface pressure (mb or hPa)
 
-rho_w = 1000.    # density of water (kg / m**3)
-cw = 4181.3      # specific heat of liquid water (J / kg / K)
+const_dict['rho_w'] = 1000.    # density of water (kg / m**3)
+const_dict['cw'] = 4181.3      # specific heat of liquid water (J / kg / K)
 
-tempCtoK = 273.15   # 0degC in Kelvin
-tempKtoC = -tempCtoK  # 0 K in degC
-mb_to_Pa = 100.  # conversion factor from mb to Pa
+const_dict['tempCtoK'] = 273.15   # 0degC in Kelvin
+const_dict['tempKtoC'] = -const_dict['tempCtoK']  # 0 K in degC
+const_dict['mb_to_Pa'] = 100.  # conversion factor from mb to Pa
 
 #  Some useful time conversion factors
-seconds_per_minute = 60.
-minutes_per_hour = 60.
-hours_per_day = 24.
+const_dict['seconds_per_minute'] = 60.
+const_dict['minutes_per_hour'] = 60.
+const_dict['hours_per_day'] = 24.
 
 # the length of the "tropical year" -- time between vernal equinoxes
 # This value is consistent with Berger (1978)
 # "Long-Term Variations of Daily Insolation and Quaternary Climatic Changes"
-days_per_year = 365.2422
-seconds_per_hour = minutes_per_hour * seconds_per_minute
-minutes_per_day = hours_per_day * minutes_per_hour
-seconds_per_day = hours_per_day * seconds_per_hour
-seconds_per_year = seconds_per_day * days_per_year
-minutes_per_year = seconds_per_year / seconds_per_minute
-hours_per_year = seconds_per_year / seconds_per_hour
+const_dict['days_per_year'] = 365.2422
+const_dict['seconds_per_hour'] = const_dict['minutes_per_hour'] * const_dict['seconds_per_minute']
+const_dict['minutes_per_day'] = const_dict['hours_per_day'] * const_dict['minutes_per_hour']
+const_dict['seconds_per_day'] = const_dict['hours_per_day'] * const_dict['seconds_per_hour']
+const_dict['seconds_per_year'] = const_dict['seconds_per_day'] * const_dict['days_per_year']
+const_dict['minutes_per_year'] = const_dict['seconds_per_year'] / const_dict['seconds_per_minute']
+const_dict['hours_per_year'] = const_dict['seconds_per_year'] / const_dict['seconds_per_hour']
 #  average lenghts of months based on dividing the year into 12 equal parts
-months_per_year = 12.
-seconds_per_month = seconds_per_year / months_per_year
-minutes_per_month = minutes_per_year / months_per_year
-hours_per_month = hours_per_year / months_per_year
-days_per_month = days_per_year / months_per_year
+const_dict['months_per_year'] = 12.
+const_dict['seconds_per_month'] = const_dict['seconds_per_year'] / const_dict['months_per_year']
+const_dict['minutes_per_month'] = const_dict['minutes_per_year'] / const_dict['months_per_year']
+const_dict['hours_per_month'] = const_dict['hours_per_year'] / const_dict['months_per_year']
+const_dict['days_per_month'] = const_dict['days_per_year'] / const_dict['months_per_year']
 
-area_earth = 4 * pi * a**2
+const_dict['area_earth'] = 4 * pi * const_dict['a']**2
 
 # present-day orbital parameters in dictionary form
-orb_present = {'ecc': 0.017236, 'long_peri': 281.37, 'obliquity': 23.446}
+const_dict['orb_present'] = {'ecc': 0.017236, 'long_peri': 281.37, 'obliquity': 23.446}
 #  usage should be indentical to
     #from climlab.solar.orbital import OrbitalTable
     #orb_present = OrbitalTable.sel(kyear=-0)
 # But avoids reading the data file unnecessarily
 
 # Molecular weights in g/mol
-molecular_weight = {'N2': 28.,
+const_dict['molecular_weight'] = {'N2': 28.,
                     'O2': 32.,
                     'H2O': 18.01528,
                     'CO2': 44.,

--- a/climlab/utils/heat_capacity.py
+++ b/climlab/utils/heat_capacity.py
@@ -1,7 +1,7 @@
 """Routines for calculating heat capacities for grid boxes."""
 
 from __future__ import division
-from climlab import constants as const
+from climlab.utils.constants import const_dict as const
 
 
 def atmosphere(dp):

--- a/climlab/utils/thermo.py
+++ b/climlab/utils/thermo.py
@@ -5,10 +5,10 @@ thermodynamic calculations for the atmosphere.
 
 from __future__ import division
 from numpy import exp, log
-from .constants import (ps, kappa, tempCtoK, eps, Rd, Rv, cpv, cp, g, Lhvap,
-                        sigma, hPlanck, c_light, kBoltzmann, molecular_weight)
+from .constants import const_dict
 
-def potential_temperature(T,p):
+
+def potential_temperature(T, p, constants=const_dict):
     """Compute potential temperature for an air parcel.
 
     Input:  T is temperature in Kelvin
@@ -16,14 +16,16 @@ def potential_temperature(T,p):
     Output: potential temperature in Kelvin.
 
     """
+    ps = constants['ps']
+    kappa = constants['kappa']
     theta = T*(ps/p)**kappa
     return theta
 
-def theta(T,p):
+def theta(T, p, constants=const_dict):
     '''Convenience method, identical to thermo.potential_temperature(T,p).'''
-    return potential_temperature(T,p)
+    return potential_temperature(T,p,constants)
 
-def temperature_from_potential(theta,p):
+def temperature_from_potential(theta, p, constants=const_dict):
     """Convert potential temperature to in-situ temperature.
 
     Input:  theta is potential temperature in Kelvin
@@ -31,14 +33,16 @@ def temperature_from_potential(theta,p):
     Output: absolute temperature in Kelvin.
 
     """
+    ps = constants['ps']
+    kappa = constants['kappa']
     T = theta/((ps/p)**kappa)
     return T
 
-def T(theta,p):
+def T(theta, p, constants=const_dict):
     '''Convenience method, identical to thermo.temperature_from_potential(theta,p).'''
-    return temperature_from_potential(theta,p)
+    return temperature_from_potential(theta,p,constants)
 
-def clausius_clapeyron(T):
+def clausius_clapeyron(T, constants=const_dict):
     """Compute saturation vapor pressure as function of temperature T.
 
     Input: T is temperature in Kelvin
@@ -49,11 +53,12 @@ def clausius_clapeyron(T):
     Based on the paper by Bolton (1980, Monthly Weather Review).
 
     """
+    tempCtoK = constants['tempCtoK']
     Tcel = T - tempCtoK
     es = 6.112 * exp(17.67*Tcel/(Tcel+243.5))
     return es
 
-def qsat(T,p):
+def qsat(T, p, constants=const_dict):
     """Compute saturation specific humidity as function of temperature and pressure.
 
     Input:  T is temperature in Kelvin
@@ -61,31 +66,35 @@ def qsat(T,p):
     Output: saturation specific humidity (dimensionless).
 
     """
-    es = clausius_clapeyron(T)
+    eps = constants['eps']
+    es = clausius_clapeyron(T, constants)
     q = eps * es / (p - (1 - eps) * es )
     return q
 
-def virtual_temperature_from_mixing_ratio(T,w):
+def virtual_temperature_from_mixing_ratio(T, w, constants=const_dict):
     '''Virtual temperature Tv
     T is air temperature (K)
     w is water vapor mixing ratio (dimensionless)'''
+    eps = constants['eps']
     return T * ((1+w/eps)/(1+w))
 
-def vapor_pressure_from_specific_humidity(p,q):
+def vapor_pressure_from_specific_humidity(p, q, constants=const_dict):
     '''Vapor pressure (same units as input p)
     p is total air pressure
     q is specific humidity (dimensionless) -- mass of vapor per unit mass moist air'''
+    eps = constants['eps']
     return p * (q/(eps+q*(1-eps)))
 
-def mixing_ratio_from_vapor_pressure(p,e):
+def mixing_ratio_from_vapor_pressure(p, e, constants=const_dict):
     '''Water vapor mixing ratio
     p is air pressure
     e is vapor pressure
     p and e must be in same units (e.g. hPa)
     '''
+    eps = constants['eps']
     return eps * e / (p-e)
 
-def rho_moist(T,p,q):
+def rho_moist(T, p, q, constants=const_dict):
     '''Density of moist air.
     T is air temperature (K)
     p is air pressure (hPa)
@@ -93,12 +102,13 @@ def rho_moist(T,p,q):
 
     returns density in kg/m3
     '''
-    e = vapor_pressure_from_specific_humidity(p,q)
-    w = mixing_ratio_from_vapor_pressure(p,e)
-    Tv = virtual_temperature_from_mixing_ratio(T,w)
+    Rd = constants['Rd']
+    e = vapor_pressure_from_specific_humidity(p,q,constants)
+    w = mixing_ratio_from_vapor_pressure(p,e,constants)
+    Tv = virtual_temperature_from_mixing_ratio(T,w,constants)
     return p*100./ Rd/Tv
 
-def pseudoadiabat(T,p):
+def pseudoadiabat(T, p, constants=const_dict):
     """Compute the local slope of the pseudoadiabat at given temperature and pressure
 
     Inputs:   p is pressure in hPa or mb
@@ -115,7 +125,11 @@ def pseudoadiabat(T,p):
 
     Integrating the result dT/dp treating p as total pressure effectively makes the dilute assumption.
     """
-    esoverp = clausius_clapeyron(T) / p
+    tempCtoK = constants['tempCtoK']
+    Rv = constants['Rv']
+    kappa = constants['kappa']
+    cpv = constants['cpv']
+    esoverp = clausius_clapeyron(T, constants) / p
     Tcel = T - tempCtoK
     L = (2.501 - 0.00237 * Tcel) * 1.E6   # Accurate form of latent heat of vaporization in J/kg
     ratio = L / T /  Rv
@@ -123,7 +137,7 @@ def pseudoadiabat(T,p):
         (1 + kappa * (cpv / Rv + (ratio-1) * ratio) * esoverp))
     return dTdp
 
-def lifting_condensation_level(T, RH):
+def lifting_condensation_level(T, RH, constants=const_dict):
     '''Compute the Lifiting Condensation Level (LCL) for a given temperature and relative humidity
 
     Inputs:  T is temperature in Kelvin
@@ -137,10 +151,12 @@ def lifting_condensation_level(T, RH):
 
     For an exact formula see Romps (2017 JAS), doi:10.1175/JAS-D-17-0102.1
     '''
+    cp = constants['cp']
+    g = constants['g']
     Tadj = T-55.  # in Kelvin
     return cp/g*(Tadj - (1/Tadj - log(RH)/2840.)**(-1))
 
-def estimated_inversion_strength(T0,T700):
+def estimated_inversion_strength(T0, T700, constants=const_dict):
     '''Compute the Estimated Inversion Strength or EIS,
     following Wood and Bretherton (2006, J. Climate)
 
@@ -152,29 +168,35 @@ def estimated_inversion_strength(T0,T700):
     EIS is a normalized measure of lower tropospheric stability acccounting for
     temperature-dependence of the moist adiabat.
     '''
+    Lhvap = constants['Lhvap']
+    cp = constants['cp']
+    Rd = constants['Rd']
+    Rv = constants['Rv']
+    g = constants['g']
     # Interpolate to 850 hPa
     T850 = (T0+T700)/2.;
     # Assume 80% relative humidity to compute LCL, appropriate for marine boundary layer
-    LCL = lifting_condensation_level(T0, 0.8)
+    LCL = lifting_condensation_level(T0, 0.8, constants)
     # Lower Tropospheric Stability (theta700 - theta0)
-    LTS = potential_temperature(T700, 700) - T0
+    LTS = potential_temperature(T700, 700, constants) - T0
     #  Gammam  = -dtheta/dz is the rate of potential temperature decrease along the moist adiabat
     #  in K / m
-    Gammam = (g/cp*(1.0 - (1.0 + Lhvap*qsat(T850,850) / Rd / T850) /
-             (1.0 + Lhvap**2 * qsat(T850,850)/ cp/Rv/T850**2)))
+    Gammam = (g/cp*(1.0 - (1.0 + Lhvap*qsat(T850,850, constants) / Rd / T850) /
+             (1.0 + Lhvap**2 * qsat(T850,850, constants)/ cp/Rv/T850**2)))
     #  Assume exponential decrease of pressure with scale height given by surface temperature
     z700 = (Rd*T0/g)*log(1000./700.)
     return LTS - Gammam*(z700 - LCL)
 
-def EIS(T0,T700):
+def EIS(T0, T700, constants=const_dict):
     '''Convenience method, identical to thermo.estimated_inversion_strength(T0,T700)'''
-    return estimated_inversion_strength(T0,T700)
+    return estimated_inversion_strength(T0, T700, constants)
 
-def blackbody_emission(T):
+def blackbody_emission(T, constants=const_dict):
     '''Blackbody radiation following the Stefan-Boltzmann law.'''
+    sigma = constants['sigma']
     return sigma * T**4
 
-def Planck_frequency(nu, T):
+def Planck_frequency(nu, T, constants=const_dict):
     '''The Planck function B(nu,T):
     the flux density for blackbody radiation in frequency space
     nu is frequency in 1/s
@@ -182,9 +204,12 @@ def Planck_frequency(nu, T):
 
     Formula (3.1) from Raymond Pierrehumbert, "Principles of Planetary Climate"
     '''
+    hPlanck = constants['hPlanck']
+    kBoltzmann = constants['kBoltzmann']
+    c_light = constants['c_light']
     return 2*hPlanck*nu**3/c_light**2/(exp(hPlanck*nu/kBoltzmann/T)-1)
 
-def Planck_wavenumber(n, T):
+def Planck_wavenumber(n, T, constants=const_dict):
     '''The Planck function (flux density for blackbody radition)
     in wavenumber space
     n is wavenumber in 1/cm
@@ -192,11 +217,12 @@ def Planck_wavenumber(n, T):
 
     Formula from Raymond Pierrehumbert, "Principles of Planetary Climate", page 140.
     '''
+    c_light = constants['c_light']
     # convert to mks units
     n = n*100.
-    return c_light * Planck_frequency(n*c_light, T)
+    return c_light * Planck_frequency(n*c_light, T, constants)
 
-def Planck_wavelength(l, T):
+def Planck_wavelength(l, T, constants=const_dict):
     '''The Planck function (flux density for blackbody radiation)
     in wavelength space
     l is wavelength in meters
@@ -204,19 +230,24 @@ def Planck_wavelength(l, T):
 
     Formula (3.3) from Raymond Pierrehumbert, "Principles of Planetary Climate"
     '''
+    hPlanck = constants['hPlanck']
+    kBoltzmann = constants['kBoltzmann']
+    c_light = constants['c_light']
     u = hPlanck*c_light/l/kBoltzmann/T
     return 2*kBoltzmann**5*T**5/hPlanck**4/c_light**3*u**5/(exp(u)-1)
 
-def vmr_to_mmr(vmr, gas):
+def vmr_to_mmr(vmr, gas, constants=const_dict):
     '''
     Convert volume mixing ratio to mass mixing ratio for named gas.
     ( molecular weights are specific in climlab.utils.constants.py )
     '''
+    molecular_weight = constants['molecular_weight']
     return vmr * molecular_weight[gas] / molecular_weight['dry air']
 
-def mmr_to_vmr(mmr, gas):
+def mmr_to_vmr(mmr, gas, constants=const_dict):
     '''
     Convert mass mixing ratio to volume mixing ratio for named gas.
     ( molecular weights are specific in climlab.utils.constants.py )
     '''
+    molecular_weight = constants['molecular_weight']
     return mmr * molecular_weight['dry air'] / molecular_weight[gas]

--- a/docs/source/code_input_manual/example_EBM_seasonal.py
+++ b/docs/source/code_input_manual/example_EBM_seasonal.py
@@ -1,5 +1,5 @@
 import climlab
-from climlab.utils import constants as const
+from climlab.utils.constants import const_dict as const
 import numpy as np
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
Proof-of-concept addressing #120 

Here we add a new attribute `const` to every Process object, which by default is a dictionary of all the standard physical constants.

User can then make modified copies of the dictionary and pass as input to new models.

Currently implemented only for the EBM. For example:
```
import climlab
from attrdict import AttrDict
e1 = climlab.EBM() 
const2 = AttrDict(e1.const)
const2['a'] *= 2.  # double the radius of the planet 
e2 = climlab.EBM(const=const2) 
e1.step_forward()
e2.step_forward()
# the heat transport is different due to the different sizes
print(e2.heat_transport - e1.heat_transport)
```

I don't necessarily think this is best implementation but just wanted to see if this works.