### PR TITLE
Changing fill_value from None to 'extrapolate' for ozone data

### DIFF
--- a/climlab/radiation/radiation.py
+++ b/climlab/radiation/radiation.py
@@ -155,9 +155,9 @@ def default_absorbers(Tatm,
         except:
             warnings.warn('Some grid points are beyond the bounds of the ozone file. Ozone values will be extrapolated.')
             try:
-                # passing fill_value=None to the underlying scipy interpolator
+                # passing fill_value='extrapolate' to the underlying scipy interpolator
                 # will result in extrapolation instead of NaNs
-                O3 = O3source.interp_like(xTatm, kwargs={'fill_value':None})
+                O3 = O3source.interp_like(xTatm, kwargs={'fill_value':'extrapolate'})
                 assert not np.any(np.isnan(O3))
             except:
                 warnings.warn('Interpolation of ozone data failed. Setting O3 to zero instead.')


### PR DESCRIPTION
For an `xr.DataArray()` with 1-dimensional coordinates, `da.interp_like()` actually calls scipy's [interp1d](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html) function, rather than [interpn](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interpn.html). As a result, to extrapolate to values outside the domain, you need to pass `fill_value='extrapolate'`, rather than `fill_value=None`.