### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,6 @@
 name: Build and test climlab
 
-on: 
+on:
   push:
   pull_request:
   workflow_dispatch:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [Ubuntu, macOS, Windows]
         include:
           - os: Ubuntu

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [Ubuntu, macOS, Windows]
         include:
           - os: Ubuntu

--- a/README.rst
+++ b/README.rst
@@ -96,10 +96,9 @@ These are handled automatically if you install with conda_.
 
 Required
 ~~~~~~~~~~~~
-- Python (currently testing on versions 3.7, 3.8, 3.9)
+- Python (currently testing on versions 3.7, 3.8, 3.9, 3.10)
 - numpy
 - scipy
-- attrdict
 - future
 - pooch (for remote data access and caching)
 - xarray (for data handling)
@@ -154,6 +153,12 @@ These are self-describing, and should run out-of-the-box once the package is ins
 
 Release history
 ----------------------
+
+Version 0.7.13 (released February 2022)
+    Maintenance release to support Python 3.10.
+
+    The `attrdict package`_ by `Brendan Curran-Johnson`_ has been removed from the dependencies since it is broken on Python 3.10 and no longer under development.
+    A modified version of the MIT-licensed attrdict source is now bundled internally with climlab. There are no changes to climlab's public API.
 
 Version 0.7.12 (released May 2021)
     New feature: spectral output from RRTMG (accompanied by a new tutorial)
@@ -302,6 +307,8 @@ The documentation_ was first created by Moritz Kreuzer
 .. _`tutorials in the docs`: https://climlab.readthedocs.io/en/latest/tutorial.html
 .. _here: http://climlab.readthedocs.io
 .. _`The Climate Laboratory`: https://brian-rose.github.io/ClimateLaboratoryBook/
+.. _`attrdict package`: https://github.com/bcj/AttrDict
+.. _`Brendan Curran-Johnson`: https://github.com/bcj
 
 
 Contact and Bug Reports

--- a/ci/requirements-linux.yml
+++ b/ci/requirements-linux.yml
@@ -10,7 +10,6 @@ dependencies:
   - fortran-compiler
   - toolchain3
   - future
-  - attrdict
   - pytest
   - codecov
   - pytest-cov

--- a/ci/requirements-macos.yml
+++ b/ci/requirements-macos.yml
@@ -10,7 +10,6 @@ dependencies:
   - gfortran_osx-64
   - libgfortran
   - future
-  - attrdict
   - pytest
   - codecov
   - pytest-cov

--- a/ci/requirements-windows.yml
+++ b/ci/requirements-windows.yml
@@ -10,4 +10,3 @@ dependencies:
   - scipy
   - flang
   - future
-  - attrdict

--- a/climlab/__init__.py
+++ b/climlab/__init__.py
@@ -7,7 +7,7 @@ Nevertheless also the underlying code of the ``climlab`` architecture
 has been documented for a comprehensive understanding and traceability.
 '''
 
-__version__ = '0.7.12'
+__version__ = '0.7.13dev0'
 
 # this should ensure that we can still import constants.py as climlab.constants
 from .utils import constants, thermo, legendre

--- a/climlab/domain/initial.py
+++ b/climlab/domain/initial.py
@@ -3,7 +3,7 @@ from __future__ import division
 import numpy as np
 from climlab.domain import domain
 from climlab.domain.field import Field
-from attrdict import AttrDict
+from climlab.utils.attrdict import AttrDict
 from climlab.utils import legendre
 
 

--- a/climlab/process/process.py
+++ b/climlab/process/process.py
@@ -70,7 +70,7 @@ import numpy as np
 from climlab.domain.field import Field
 from climlab.domain.domain import _Domain, zonal_mean_surface
 from climlab.utils import walk
-from attrdict import AttrDict
+from climlab.utils.attrdict import AttrDict
 from climlab.domain.xarray import state_to_xarray
 
 

--- a/climlab/process/time_dependent_process.py
+++ b/climlab/process/time_dependent_process.py
@@ -7,7 +7,7 @@ import copy
 from climlab import constants as const
 from .process import Process
 from climlab.utils import walk
-from attrdict import AttrDict
+from climlab.utils.attrdict import AttrDict
 
 
 def couple(proclist, name='Parent'):

--- a/climlab/utils/attrdict/__init__.py
+++ b/climlab/utils/attrdict/__init__.py
@@ -1,0 +1,10 @@
+"""
+attrdict contains several mapping objects that allow access to their
+keys as attributes.
+"""
+from .mapping import AttrMap
+from .dictionary import AttrDict
+from .default import AttrDefault
+
+
+__all__ = ['AttrMap', 'AttrDict', 'AttrDefault']

--- a/climlab/utils/attrdict/default.py
+++ b/climlab/utils/attrdict/default.py
@@ -1,0 +1,130 @@
+"""
+A subclass of MutableAttr that has defaultdict support.
+"""
+from collections import Mapping
+
+import six
+
+from .mixins import MutableAttr
+
+
+__all__ = ['AttrDefault']
+
+
+class AttrDefault(MutableAttr):
+    """
+    An implementation of MutableAttr with defaultdict support
+    """
+    def __init__(self, default_factory=None, items=None, sequence_type=tuple,
+                 pass_key=False):
+        if items is None:
+            items = {}
+        elif not isinstance(items, Mapping):
+            items = dict(items)
+
+        self._setattr('_default_factory', default_factory)
+        self._setattr('_mapping', items)
+        self._setattr('_sequence_type', sequence_type)
+        self._setattr('_pass_key', pass_key)
+        self._setattr('_allow_invalid_attributes', False)
+
+    def _configuration(self):
+        """
+        The configuration for a AttrDefault instance
+        """
+        return self._sequence_type, self._default_factory, self._pass_key
+
+    def __getitem__(self, key):
+        """
+        Access a value associated with a key.
+
+        Note: values returned will not be wrapped, even if recursive
+        is True.
+        """
+        if key in self._mapping:
+            return self._mapping[key]
+        elif self._default_factory is not None:
+            return self.__missing__(key)
+
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        """
+        Add a key-value pair to the instance.
+        """
+        self._mapping[key] = value
+
+    def __delitem__(self, key):
+        """
+        Delete a key-value pair
+        """
+        del self._mapping[key]
+
+    def __len__(self):
+        """
+        Check the length of the mapping.
+        """
+        return len(self._mapping)
+
+    def __iter__(self):
+        """
+        Iterated through the keys.
+        """
+        return iter(self._mapping)
+
+    def __missing__(self, key):
+        """
+        Add a missing element.
+        """
+        if self._pass_key:
+            self[key] = value = self._default_factory(key)
+        else:
+            self[key] = value = self._default_factory()
+
+        return value
+
+    def __repr__(self):
+        """
+        Return a string representation of the object.
+        """
+        return six.u(
+            "AttrDefault({default_factory}, {pass_key}, {mapping})"
+        ).format(
+            default_factory=repr(self._default_factory),
+            pass_key=repr(self._pass_key),
+            mapping=repr(self._mapping),
+        )
+
+    def __getstate__(self):
+        """
+        Serialize the object.
+        """
+        return (
+            self._default_factory,
+            self._mapping,
+            self._sequence_type,
+            self._pass_key,
+            self._allow_invalid_attributes,
+        )
+
+    def __setstate__(self, state):
+        """
+        Deserialize the object.
+        """
+        (default_factory, mapping, sequence_type, pass_key,
+         allow_invalid_attributes) = state
+
+        self._setattr('_default_factory', default_factory)
+        self._setattr('_mapping', mapping)
+        self._setattr('_sequence_type', sequence_type)
+        self._setattr('_pass_key', pass_key)
+        self._setattr('_allow_invalid_attributes', allow_invalid_attributes)
+
+    @classmethod
+    def _constructor(cls, mapping, configuration):
+        """
+        A standardized constructor.
+        """
+        sequence_type, default_factory, pass_key = configuration
+        return cls(default_factory, mapping, sequence_type=sequence_type,
+                   pass_key=pass_key)

--- a/climlab/utils/attrdict/default.py
+++ b/climlab/utils/attrdict/default.py
@@ -1,7 +1,7 @@
 """
 A subclass of MutableAttr that has defaultdict support.
 """
-from collections import Mapping
+from collections.abc import Mapping
 
 import six
 

--- a/climlab/utils/attrdict/dictionary.py
+++ b/climlab/utils/attrdict/dictionary.py
@@ -1,0 +1,60 @@
+"""
+A dict that implements MutableAttr.
+"""
+from .mixins import MutableAttr
+
+import six
+
+
+__all__ = ['AttrDict']
+
+
+class AttrDict(dict, MutableAttr):
+    """
+    A dict that implements MutableAttr.
+    """
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+
+        self._setattr('_sequence_type', tuple)
+        self._setattr('_allow_invalid_attributes', False)
+
+    def _configuration(self):
+        """
+        The configuration for an attrmap instance.
+        """
+        return self._sequence_type
+
+    def __getstate__(self):
+        """
+        Serialize the object.
+        """
+        return (
+            self.copy(),
+            self._sequence_type,
+            self._allow_invalid_attributes
+        )
+
+    def __setstate__(self, state):
+        """
+        Deserialize the object.
+        """
+        mapping, sequence_type, allow_invalid_attributes = state
+        self.update(mapping)
+        self._setattr('_sequence_type', sequence_type)
+        self._setattr('_allow_invalid_attributes', allow_invalid_attributes)
+
+    def __repr__(self):
+        return six.u('AttrDict({contents})').format(
+            contents=super(AttrDict, self).__repr__()
+        )
+
+    @classmethod
+    def _constructor(cls, mapping, configuration):
+        """
+        A standardized constructor.
+        """
+        attr = cls(mapping)
+        attr._setattr('_sequence_type', configuration)
+
+        return attr

--- a/climlab/utils/attrdict/mapping.py
+++ b/climlab/utils/attrdict/mapping.py
@@ -1,0 +1,97 @@
+"""
+An implementation of MutableAttr.
+"""
+from collections import Mapping
+
+import six
+
+from .mixins import MutableAttr
+
+
+__all__ = ['AttrMap']
+
+
+class AttrMap(MutableAttr):
+    """
+    An implementation of MutableAttr.
+    """
+    def __init__(self, items=None, sequence_type=tuple):
+        if items is None:
+            items = {}
+        elif not isinstance(items, Mapping):
+            items = dict(items)
+
+        self._setattr('_sequence_type', sequence_type)
+        self._setattr('_mapping', items)
+        self._setattr('_allow_invalid_attributes', False)
+
+    def _configuration(self):
+        """
+        The configuration for an attrmap instance.
+        """
+        return self._sequence_type
+
+    def __getitem__(self, key):
+        """
+        Access a value associated with a key.
+        """
+        return self._mapping[key]
+
+    def __setitem__(self, key, value):
+        """
+        Add a key-value pair to the instance.
+        """
+        self._mapping[key] = value
+
+    def __delitem__(self, key):
+        """
+        Delete a key-value pair
+        """
+        del self._mapping[key]
+
+    def __len__(self):
+        """
+        Check the length of the mapping.
+        """
+        return len(self._mapping)
+
+    def __iter__(self):
+        """
+        Iterated through the keys.
+        """
+        return iter(self._mapping)
+
+    def __repr__(self):
+        """
+        Return a string representation of the object.
+        """
+        # sequence type seems like more trouble than it is worth.
+        # If people want full serialization, they can pickle, and in
+        # 99% of cases, sequence_type won't change anyway
+        return six.u("AttrMap({mapping})").format(mapping=repr(self._mapping))
+
+    def __getstate__(self):
+        """
+        Serialize the object.
+        """
+        return (
+            self._mapping,
+            self._sequence_type,
+            self._allow_invalid_attributes
+        )
+
+    def __setstate__(self, state):
+        """
+        Deserialize the object.
+        """
+        mapping, sequence_type, allow_invalid_attributes = state
+        self._setattr('_mapping', mapping)
+        self._setattr('_sequence_type', sequence_type)
+        self._setattr('_allow_invalid_attributes', allow_invalid_attributes)
+
+    @classmethod
+    def _constructor(cls, mapping, configuration):
+        """
+        A standardized constructor.
+        """
+        return cls(mapping, sequence_type=configuration)

--- a/climlab/utils/attrdict/mapping.py
+++ b/climlab/utils/attrdict/mapping.py
@@ -1,7 +1,7 @@
 """
 An implementation of MutableAttr.
 """
-from collections import Mapping
+from collections.abc import Mapping
 
 import six
 

--- a/climlab/utils/attrdict/merge.py
+++ b/climlab/utils/attrdict/merge.py
@@ -1,0 +1,44 @@
+"""
+A right-favoring Mapping merge.
+"""
+from collections import Mapping
+
+
+__all__ = ['merge']
+
+
+def merge(left, right):
+    """
+    Merge two mappings objects together, combining overlapping Mappings,
+    and favoring right-values
+
+    left: The left Mapping object.
+    right: The right (favored) Mapping object.
+
+    NOTE: This is not commutative (merge(a,b) != merge(b,a)).
+    """
+    merged = {}
+
+    left_keys = frozenset(left)
+    right_keys = frozenset(right)
+
+    # Items only in the left Mapping
+    for key in left_keys - right_keys:
+        merged[key] = left[key]
+
+    # Items only in the right Mapping
+    for key in right_keys - left_keys:
+        merged[key] = right[key]
+
+    # in both
+    for key in left_keys & right_keys:
+        left_value = left[key]
+        right_value = right[key]
+
+        if (isinstance(left_value, Mapping) and
+                isinstance(right_value, Mapping)):  # recursive merge
+            merged[key] = merge(left_value, right_value)
+        else:  # overwrite with right value
+            merged[key] = right_value
+
+    return merged

--- a/climlab/utils/attrdict/merge.py
+++ b/climlab/utils/attrdict/merge.py
@@ -1,7 +1,7 @@
 """
 A right-favoring Mapping merge.
 """
-from collections import Mapping
+from collections.abc import Mapping
 
 
 __all__ = ['merge']

--- a/climlab/utils/attrdict/mixins.py
+++ b/climlab/utils/attrdict/mixins.py
@@ -2,7 +2,7 @@
 Mixin Classes for Attr-support.
 """
 from abc import ABCMeta, abstractmethod
-from collections import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 import re
 
 import six

--- a/climlab/utils/attrdict/mixins.py
+++ b/climlab/utils/attrdict/mixins.py
@@ -1,0 +1,209 @@
+"""
+Mixin Classes for Attr-support.
+"""
+from abc import ABCMeta, abstractmethod
+from collections import Mapping, MutableMapping, Sequence
+import re
+
+import six
+
+from .merge import merge
+
+
+__all__ = ['Attr', 'MutableAttr']
+
+
+@six.add_metaclass(ABCMeta)
+class Attr(Mapping):
+    """
+    A mixin class for a mapping that allows for attribute-style access
+    of values.
+
+    A key may be used as an attribute if:
+     * It is a string
+     * It matches /^[A-Za-z][A-Za-z0-9_]*$/ (i.e., a public attribute)
+     * The key doesn't overlap with any class attributes (for Attr,
+        those would be 'get', 'items', 'keys', 'values', 'mro', and
+        'register').
+
+    If a values which is accessed as an attribute is a Sequence-type
+    (and is not a string/bytes), it will be converted to a
+    _sequence_type with any mappings within it converted to Attrs.
+
+    NOTE: This means that if _sequence_type is not None, then a
+        sequence accessed as an attribute will be a different object
+        than if accessed as an attribute than if it is accessed as an
+        item.
+    """
+    @abstractmethod
+    def _configuration(self):
+        """
+        All required state for building a new instance with the same
+        settings as the current object.
+        """
+
+    @classmethod
+    def _constructor(cls, mapping, configuration):
+        """
+        A standardized constructor used internally by Attr.
+
+        mapping: A mapping of key-value pairs. It is HIGHLY recommended
+            that you use this as the internal key-value pair mapping, as
+            that will allow nested assignment (e.g., attr.foo.bar = baz)
+        configuration: The return value of Attr._configuration
+        """
+        raise NotImplementedError("You need to implement this")
+
+    def __call__(self, key):
+        """
+        Dynamically access a key-value pair.
+
+        key: A key associated with a value in the mapping.
+
+        This differs from __getitem__, because it returns a new instance
+        of an Attr (if the value is a Mapping object).
+        """
+        if key not in self:
+            raise AttributeError(
+                "'{cls} instance has no attribute '{name}'".format(
+                    cls=self.__class__.__name__, name=key
+                )
+            )
+
+        return self._build(self[key])
+
+    def __getattr__(self, key):
+        """
+        Access an item as an attribute.
+        """
+        if key not in self or not self._valid_name(key):
+            raise AttributeError(
+                "'{cls}' instance has no attribute '{name}'".format(
+                    cls=self.__class__.__name__, name=key
+                )
+            )
+
+        return self._build(self[key])
+
+    def __add__(self, other):
+        """
+        Add a mapping to this Attr, creating a new, merged Attr.
+
+        other: A mapping.
+
+        NOTE: Addition is not commutative. a + b != b + a.
+        """
+        if not isinstance(other, Mapping):
+            return NotImplemented
+
+        return self._constructor(merge(self, other), self._configuration())
+
+    def __radd__(self, other):
+        """
+        Add this Attr to a mapping, creating a new, merged Attr.
+
+        other: A mapping.
+
+        NOTE: Addition is not commutative. a + b != b + a.
+        """
+        if not isinstance(other, Mapping):
+            return NotImplemented
+
+        return self._constructor(merge(other, self), self._configuration())
+
+    def _build(self, obj):
+        """
+        Conditionally convert an object to allow for recursive mapping
+        access.
+
+        obj: An object that was a key-value pair in the mapping. If obj
+            is a mapping, self._constructor(obj, self._configuration())
+            will be called. If obj is a non-string/bytes sequence, and
+            self._sequence_type is not None, the obj will be converted
+            to type _sequence_type and build will be called on its
+            elements.
+        """
+        if isinstance(obj, Mapping):
+            obj = self._constructor(obj, self._configuration())
+        elif (isinstance(obj, Sequence) and
+              not isinstance(obj, (six.string_types, six.binary_type))):
+            sequence_type = getattr(self, '_sequence_type', None)
+
+            if sequence_type:
+                obj = sequence_type(self._build(element) for element in obj)
+
+        return obj
+
+    @classmethod
+    def _valid_name(cls, key):
+        """
+        Check whether a key is a valid attribute name.
+
+        A key may be used as an attribute if:
+         * It is a string
+         * It matches /^[A-Za-z][A-Za-z0-9_]*$/ (i.e., a public attribute)
+         * The key doesn't overlap with any class attributes (for Attr,
+            those would be 'get', 'items', 'keys', 'values', 'mro', and
+            'register').
+        """
+        return (
+            isinstance(key, six.string_types) and
+            re.match('^[A-Za-z][A-Za-z0-9_]*$', key) and
+            not hasattr(cls, key)
+        )
+
+
+@six.add_metaclass(ABCMeta)
+class MutableAttr(Attr, MutableMapping):
+    """
+    A mixin class for a mapping that allows for attribute-style access
+    of values.
+    """
+    def _setattr(self, key, value):
+        """
+        Add an attribute to the object, without attempting to add it as
+        a key to the mapping.
+        """
+        super(MutableAttr, self).__setattr__(key, value)
+
+    def __setattr__(self, key, value):
+        """
+        Add an attribute.
+
+        key: The name of the attribute
+        value: The attributes contents
+        """
+        if self._valid_name(key):
+            self[key] = value
+        elif getattr(self, '_allow_invalid_attributes', True):
+            super(MutableAttr, self).__setattr__(key, value)
+        else:
+            raise TypeError(
+                "'{cls}' does not allow attribute creation.".format(
+                    cls=self.__class__.__name__
+                )
+            )
+
+    def _delattr(self, key):
+        """
+        Delete an attribute from the object, without attempting to
+        remove it from the mapping.
+        """
+        super(MutableAttr, self).__delattr__(key)
+
+    def __delattr__(self, key, force=False):
+        """
+        Delete an attribute.
+
+        key: The name of the attribute
+        """
+        if self._valid_name(key):
+            del self[key]
+        elif getattr(self, '_allow_invalid_attributes', True):
+            super(MutableAttr, self).__delattr__(key)
+        else:
+            raise TypeError(
+                "'{cls}' does not allow attribute deletion.".format(
+                    cls=self.__class__.__name__
+                )
+            )

--- a/climlab/utils/attrdict/setup.py
+++ b/climlab/utils/attrdict/setup.py
@@ -3,8 +3,7 @@ from __future__ import division, print_function
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
-    config = Configuration(package_name='utils', parent_name=parent_package, top_path=top_path)
-    config.add_subpackage('attrdict')
+    config = Configuration(package_name='attrdict', parent_name=parent_package, top_path=top_path)
     return config
 
 if __name__ == '__main__':

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.12" %}
+{% set version = "0.7.13dev0" %}
 
 package:
   name: climlab
@@ -29,7 +29,6 @@ requirements:
     - pooch
     - xarray
     - future
-    - attrdict
 
 test:
   requires:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,6 @@ dependencies:
     - netCDF4
     - xarray
     - pooch
-    - attrdict
     - sphinx
     - ipython
     - jupyter

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -76,10 +76,9 @@ These are handled automatically if you install with conda_.
 
 Required
 ------------
-- Python (currently testing on versions 3.7, 3.8, 3.9)
+- Python (currently testing on versions 3.7, 3.8, 3.9, 3.10)
 - numpy
 - scipy
-- attrdict
 - future
 - pooch (for remote data access and caching)
 - xarray (for data handling)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import os
 
-VERSION = '0.7.12'
+VERSION = '0.7.13dev0'
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,
@@ -70,7 +70,7 @@ def setup_package():
           author='Brian E. J. Rose',
           author_email='brose@albany.edu',
           setup_requires=['numpy'],
-          install_requires=['numpy','xarray','attrdict','scipy'],
+          install_requires=['numpy','xarray','scipy'],
           license='MIT',
     )
     run_build = True


### PR DESCRIPTION
Remove attrdict package from dependencies (incompatible with Python 3.10)

Instead I've bundled the source code from [the archived attrdict project home](https://github.com/bcj/AttrDict) into `climlab.utils`, and changed the import paths for the `Mappings` abstract base class so that it continues to work under Python 3.10

Also switched on testing for Python 3.10 to the GitHub workflow matrix.